### PR TITLE
feat: add BrowserAgent driving contract with agent sessions

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -121,6 +121,7 @@ flowchart
     ExtensionToolCallUseCases
     PublishBrowserStateUseCase
     BrowserAgentUseCases
+    AgentSessionRegistry
   end
   subgraph Driven["Driven"]
     direction LR
@@ -135,7 +136,7 @@ flowchart
   Driving --> Core --> Driven
 
   classDef planned stroke-dasharray:5 5,stroke:#999,color:#999;
-  class BrowserAgent,BrowserAgentUseCases,LlmProvider planned;
+  class BrowserAgent,BrowserAgentUseCases,AgentSessionRegistry,LlmProvider planned;
 ```
 
 ## L2 - Extension Tool Calls
@@ -186,6 +187,15 @@ flowchart TB
 
 ## L2 - Browser Agent (planned)
 
+The Browser Agent is a **single agent that owns many sessions**. `BrowserAgentUseCases`
+wraps one AI SDK v7 [`HarnessAgent`](https://ai-sdk.dev/v7/docs/ai-sdk-harnesses/harness-agent)
+held as a DI singleton ("construct the agent once; it holds configuration, not a live
+session"). Each `AgentSession` maps to a harness session that owns its own conversation
+history; an `AgentSessionRegistry` tracks the live set (peer of the server core's
+`BrowserStateRegistry`). `session.detach()` → resume state + `createSession({ resumeFrom })`
+is the seam for persisting sessions across service-worker eviction (adapter deferred).
+`LlmProvider` remains the Driven node, realized by the harness/model adapter (rename deferred).
+
 ```mermaid
 ---
 title: Extension Core — Browser Agent (planned)
@@ -196,19 +206,21 @@ flowchart TB
   end
   subgraph Core["Core"]
     BrowserAgentUseCases
+    AgentSessionRegistry
     ExtensionToolCallUseCases
   end
   subgraph Driven["Driven"]
     LlmProvider
     BrowserDriver
   end
-  BrowserAgent --> BrowserAgentUseCases
+  BrowserAgent -->|"createSession / sendMessage / cancel"| BrowserAgentUseCases
+  BrowserAgentUseCases -->|"owns N sessions"| AgentSessionRegistry
   BrowserAgentUseCases --> LlmProvider
   BrowserAgentUseCases --> ExtensionToolCallUseCases
   ExtensionToolCallUseCases --> BrowserDriver
 
   classDef planned stroke-dasharray:5 5,stroke:#999,color:#999;
-  class BrowserAgent,BrowserAgentUseCases,LlmProvider planned;
+  class BrowserAgent,BrowserAgentUseCases,AgentSessionRegistry,LlmProvider planned;
 ```
 
 # L1 - Extension Architecture
@@ -322,6 +334,7 @@ flowchart TD
     end
     subgraph Core["Core"]
       BrowserAgentUseCases["BrowserAgentUseCases"]
+      AgentSessionRegistry["AgentSessionRegistry"]
       ExtensionToolCallUseCases["ExtensionToolCallUseCases"]
     end
     subgraph Driven["Driven"]
@@ -331,13 +344,14 @@ flowchart TD
     end
   end
 
-  AgentApp -->|"messages"| AgentRpcController
-  AgentRpcController -->|"progress events"| AgentApp
+  AgentApp -->|"createSession / sendMessage / cancel"| AgentRpcController
+  AgentRpcController -->|"progress events (per session)"| AgentApp
   AgentRpcController --> BrowserAgentUseCases
+  BrowserAgentUseCases -->|"owns N sessions"| AgentSessionRegistry
   BrowserAgentUseCases --> LlmProvider
   BrowserAgentUseCases --> ExtensionToolCallUseCases
   ExtensionToolCallUseCases --> BrowserDriver
 
   classDef planned stroke-dasharray:5 5,stroke:#999,color:#999;
-  class AgentApp,AgentApp,AgentRpcController,BrowserAgentUseCases,LlmProvider planned;
+  class AgentApp,AgentRpcController,BrowserAgentUseCases,AgentSessionRegistry,LlmProvider planned;
 ```

--- a/packages/core-extension/src/input-ports/browser-agent.ts
+++ b/packages/core-extension/src/input-ports/browser-agent.ts
@@ -1,0 +1,96 @@
+import type {
+	AgentCreateSessionParams,
+	AgentProgressEvent,
+	AgentSendMessageParams,
+	AgentSession,
+} from "../types";
+
+/** Listener invoked for every {@link AgentProgressEvent} the agent emits. */
+export type AgentEventListener = (event: AgentProgressEvent) => void;
+
+/** Returned by {@link BrowserAgentInputPort.subscribe} to detach a listener. */
+export type AgentUnsubscribe = () => void;
+
+/**
+ * Driving contract for the Browser Agent (the `BrowserAgentUseCases` node in
+ * `docs/architecture.md`). The `AgentRpcController` driving adapter is the only
+ * caller: it translates `mbk:agent` channel messages into these methods and
+ * forwards every {@link AgentProgressEvent} from `subscribe` back to the
+ * `apps/agent-ui` SPA.
+ *
+ * This is a *single* agent that owns *many* sessions. The implementation (a
+ * later, non-driving pass) wraps one AI SDK v7 `HarnessAgent` held as a DI
+ * singleton — "construct the agent once; it holds configuration, not a live
+ * session". Each method maps onto the harness:
+ *
+ * - `createSession`  → `await agent.createSession({ resumeFrom? })`
+ * - `sendMessage`    → `agent.stream({ session, prompt })`, parts → events
+ * - `cancel`         → `session.stop()` (session stays usable)
+ * - `endSession`     → `session.destroy()`
+ * - `getHistory`     → the harness session's native conversation history
+ * - persistence seam → `session.detach()` → resume state + `createSession({ resumeFrom })`
+ *
+ * It reasons via the planned `LlmProviderOutputPort` (realized by the harness/
+ * model adapter) and acts via the existing `ExtensionToolCallInputPort` →
+ * `BrowserDriverOutputPort`. Those collaborators are out of scope here — this
+ * file fixes only the boundary the driving layer depends on.
+ */
+export interface BrowserAgentInputPort {
+	// --- Session lifecycle ---
+
+	/**
+	 * Open a new conversation session on the agent. Emits a `session-created`
+	 * event and returns the created {@link AgentSession}.
+	 */
+	createSession(params?: AgentCreateSessionParams): Promise<AgentSession>;
+
+	/**
+	 * Close a session: cancel any in-flight turn and discard it. Idempotent.
+	 * Emits a `session-ended` event.
+	 */
+	endSession(sessionId: string): Promise<void>;
+
+	// --- Drive ---
+
+	/**
+	 * Drive an agent turn from a user instruction on an existing session.
+	 * Resolves once the turn has been *accepted and started* — NOT when it
+	 * completes. Progress and the final outcome are reported asynchronously via
+	 * {@link subscribe}.
+	 */
+	sendMessage(params: AgentSendMessageParams): Promise<void>;
+
+	/**
+	 * Cancel the in-flight turn for a session, if any. Idempotent: cancelling a
+	 * session with no active turn is a no-op. The session stays usable (returns
+	 * to `idle`); a cancelled turn emits an `aborted` event.
+	 */
+	cancel(sessionId: string): Promise<void>;
+
+	// --- Reads (for UI hydration) ---
+
+	/** Snapshot of a single session, or `undefined` if unknown. */
+	getSession(sessionId: string): Promise<AgentSession | undefined>;
+
+	/** Snapshot of all known sessions. */
+	listSessions(): Promise<AgentSession[]>;
+
+	/**
+	 * Durable transcript for a session: the replayable subset of
+	 * {@link AgentProgressEvent}s (lifecycle, user/assistant messages, tool
+	 * activity), excluding transient `assistant-message` deltas. Lets a reopened
+	 * UI hydrate without replaying the live stream.
+	 */
+	getHistory(sessionId: string): Promise<AgentProgressEvent[]>;
+
+	// --- Stream ---
+
+	/**
+	 * Subscribe to progress events across all sessions. The driving adapter
+	 * filters by `sessionId` when fanning out to UI connections. Returns an
+	 * unsubscribe function.
+	 */
+	subscribe(listener: AgentEventListener): AgentUnsubscribe;
+}
+
+export const BrowserAgentInputPort = Symbol.for("BrowserAgentInputPort");

--- a/packages/core-extension/src/input-ports/index.ts
+++ b/packages/core-extension/src/input-ports/index.ts
@@ -1,3 +1,4 @@
+export * from "./browser-agent";
 export * from "./extension-bootstrap";
 export * from "./extension-tool-call";
 export * from "./publish-browser-state";

--- a/packages/core-extension/src/types/agent-event.ts
+++ b/packages/core-extension/src/types/agent-event.ts
@@ -1,0 +1,88 @@
+import type { AgentSession } from "./agent-session";
+import type { ExtensionToolName } from "./extension-tools";
+
+/**
+ * Outbound side of the Browser Agent driving contract.
+ *
+ * While {@link BrowserAgentInputPort} works through a session it emits a stream
+ * of {@link AgentProgressEvent}s. The `AgentRpcController` forwards them back to
+ * the `apps/agent-ui` SPA as "progress events" over the `mbk:agent` channel.
+ * The core remains transport-agnostic: it only knows it has subscribers.
+ *
+ * The union is also the replayable transcript: `getHistory` returns the durable
+ * subset of these events (lifecycle, user/assistant messages, tool activity),
+ * excluding transient `assistant-message` deltas.
+ */
+
+export interface AgentEventBase {
+	/** Conversation this event belongs to (see {@link AgentSession}). */
+	sessionId: string;
+	/**
+	 * Monotonic id for the single agent turn this event belongs to. Omitted for
+	 * pure session-lifecycle events that occur outside any turn.
+	 */
+	turnId?: string;
+	/** Epoch milliseconds when the event was produced. */
+	at: number;
+}
+
+/**
+ * A discriminated union of everything the agent reports. Session-lifecycle
+ * members let the UI track sessions reactively without re-reading
+ * `listSessions`. Tool activity reuses {@link ExtensionToolName} so the UI can
+ * render the same tool vocabulary the extension already exposes; the
+ * `tool-result` shape mirrors the server tool envelope (`ok`/`result`/`reason`).
+ */
+export type AgentProgressEvent =
+	| (AgentEventBase & {
+			type: "session-created";
+			session: AgentSession;
+	  })
+	| (AgentEventBase & {
+			type: "session-updated";
+			session: AgentSession;
+	  })
+	| (AgentEventBase & {
+			type: "session-ended";
+	  })
+	| (AgentEventBase & {
+			type: "user-message";
+			content: string;
+	  })
+	| (AgentEventBase & {
+			type: "turn-started";
+	  })
+	| (AgentEventBase & {
+			type: "assistant-message";
+			content: string;
+			/**
+			 * `false`/absent for an incremental `text-delta`; `true` on the final
+			 * coalesced message for the turn (the durable transcript entry).
+			 */
+			done?: boolean;
+	  })
+	| (AgentEventBase & {
+			type: "tool-call";
+			toolName: ExtensionToolName;
+			args: unknown[];
+	  })
+	| (AgentEventBase & {
+			type: "tool-result";
+			toolName: ExtensionToolName;
+			ok: boolean;
+			result?: unknown;
+			reason?: string;
+	  })
+	| (AgentEventBase & {
+			type: "turn-completed";
+			summary?: string;
+	  })
+	| (AgentEventBase & {
+			type: "aborted";
+	  })
+	| (AgentEventBase & {
+			type: "error";
+			message: string;
+	  });
+
+export type AgentEventType = AgentProgressEvent["type"];

--- a/packages/core-extension/src/types/agent-message.ts
+++ b/packages/core-extension/src/types/agent-message.ts
@@ -1,0 +1,33 @@
+/**
+ * Inbound side of the Browser Agent driving contract.
+ *
+ * These are the messages the `apps/agent-ui` SPA sends to the background
+ * service worker over the `runtime.connect: mbk:agent` channel. The
+ * `AgentRpcController` (driving adapter) deserializes them and invokes
+ * {@link BrowserAgentInputPort}. They are deliberately transport-agnostic so
+ * the core never depends on how the UI is wired.
+ */
+
+/** A single natural-language instruction that drives an agent turn. */
+export interface AgentUserMessage {
+	/** Free-form instruction for the agent to carry out. */
+	content: string;
+}
+
+/**
+ * Optional scope for a session. The extension always acts on its own browser,
+ * so a target only narrows the window/tab the agent should operate on; when
+ * omitted the agent decides from the current browser state. Set per session
+ * (see {@link AgentCreateSessionParams}), not per message.
+ */
+export interface AgentTarget {
+	windowId?: string;
+	tabId?: string;
+}
+
+/** Parameters for {@link BrowserAgentInputPort.sendMessage}. */
+export interface AgentSendMessageParams {
+	/** Identifies the existing session the message drives a turn on. */
+	sessionId: string;
+	message: AgentUserMessage;
+}

--- a/packages/core-extension/src/types/agent-session.ts
+++ b/packages/core-extension/src/types/agent-session.ts
@@ -1,0 +1,31 @@
+import type { AgentTarget } from "./agent-message";
+
+/**
+ * First-class agent session.
+ *
+ * The Browser Agent is a single agent (one AI SDK v7 `HarnessAgent`, held as a
+ * DI singleton); a *session* is one conversation thread on it. Each
+ * {@link AgentSession} maps to a harness session that owns its own conversation
+ * history. `sessionId` doubles as the harness resume key.
+ */
+export type AgentSessionStatus = "idle" | "running" | "error" | "ended";
+
+export interface AgentSession {
+	/** Stable id; also the underlying `HarnessAgent` session id (resume key). */
+	sessionId: string;
+	status: AgentSessionStatus;
+	/** Optional window/tab scope the session operates on. */
+	target?: AgentTarget;
+	/** Optional human label, e.g. derived from the first user message. */
+	title?: string;
+	/** Epoch milliseconds the session was created. */
+	createdAt: number;
+	/** Epoch milliseconds the session last changed. */
+	updatedAt: number;
+}
+
+/** Parameters for {@link BrowserAgentInputPort.createSession}. */
+export interface AgentCreateSessionParams {
+	target?: AgentTarget;
+	title?: string;
+}

--- a/packages/core-extension/src/types/index.ts
+++ b/packages/core-extension/src/types/index.ts
@@ -1,3 +1,6 @@
+export * from "./agent-event";
+export * from "./agent-message";
+export * from "./agent-session";
 export * from "./browser-info";
 export * from "./extension-context";
 export * from "./extension-info";


### PR DESCRIPTION
Define the Browser Agent driving boundary in core-extension as a single agent that owns many sessions (wrapping the AI SDK v7 HarnessAgent):

- BrowserAgentInputPort: session lifecycle (createSession/endSession), drive (sendMessage/cancel), reads (getSession/listSessions/getHistory), and a subscribe() progress stream.
- New types: AgentSession/AgentSessionStatus/AgentCreateSessionParams, AgentSendMessageParams, and the AgentProgressEvent transcript union (session lifecycle + user/assistant messages + tool activity).
- Update architecture diagrams: add AgentSessionRegistry Core node and note the HarnessAgent wrapping; nodes stay 'planned' (dashed).

No container binding yet — implementation, the driving package, the LLM/harness adapter, and apps/agent-ui remain a later pass.