### PR TITLE
feat: add optional value to ReadableElementRecord

### DIFF
--- a/.moon/tasks/tag-mcp.yml
+++ b/.moon/tasks/tag-mcp.yml
@@ -12,6 +12,8 @@ tasks:
   mcp-inspector:
     toolchain: node
     preset: server
+    deps:
+    - build
     script: |
       DANGEROUSLY_OMIT_AUTH=true yarn dlx @modelcontextprotocol/inspector --transport stdio -- tsx $projectRoot/target/tsup/dist/main.js
     inputs:

--- a/apps/ext-e2e-test-app/src/components/screens/form-test-screen.tsx
+++ b/apps/ext-e2e-test-app/src/components/screens/form-test-screen.tsx
@@ -198,6 +198,29 @@ export function FormTestScreen() {
 					</form>
 				</section>
 
+				<section className="mb-8">
+					<h2 className="text-2xl font-bold mb-4">Preferences</h2>
+					<label className="block mb-2">
+						<input
+							type="checkbox"
+							data-testid="subscribe-checkbox"
+							aria-label="Subscribe to newsletter"
+							defaultChecked
+							className="mr-2"
+						/>
+						Subscribe to newsletter
+					</label>
+					<label className="block">
+						<input
+							type="checkbox"
+							data-testid="marketing-checkbox"
+							aria-label="Receive marketing emails"
+							className="mr-2"
+						/>
+						Receive marketing emails
+					</label>
+				</section>
+
 				<section>
 					<h2 className="text-2xl font-bold mb-4">Current Form State</h2>
 					<div

--- a/apps/ext-e2e/src/tests/readable-element-html.spec.ts
+++ b/apps/ext-e2e/src/tests/readable-element-html.spec.ts
@@ -1,0 +1,99 @@
+import { expect, test } from "../fixtures/ext-test";
+import { expectToBeDefined } from "../test-utils/assert-defined";
+
+type SnapshotResultJson<T> = {
+	snapshotId: string;
+	pageNumber: number;
+	nextPageNumber: number | null;
+	hasNextPage: boolean;
+	totalPages: number;
+	data: T;
+};
+
+test.describe("Readable element HTML", () => {
+	test.beforeEach(async ({ mcpClientPage }) => {
+		test.setTimeout(30000);
+		await mcpClientPage.startServer();
+		await mcpClientPage.connect();
+		await mcpClientPage.waitForBrowsers();
+	});
+
+	test("getReadableElementHtml returns the element's outerHTML", async ({
+		testAppPage,
+		mcpClientPage,
+	}) => {
+		await testAppPage.navigateToFormTest();
+
+		const tab = await mcpClientPage.waitForTabByUrl(
+			testAppPage.page,
+			"form-test",
+		);
+		const tabUri = await mcpClientPage.waitForTabUriByUrl(
+			testAppPage.page,
+			"form-test",
+		);
+
+		const elements = await mcpClientPage.readAllSnapshotElements(tabUri);
+		const usernameInputPath = elements.find(
+			(el) => el[1] === "input" && el[2]?.includes("Enter username"),
+		)?.[0];
+		expectToBeDefined(usernameInputPath);
+
+		const result = await mcpClientPage.callToolJson<SnapshotResultJson<string>>(
+			"getReadableElementHtml",
+			{
+				browserId: tab.browserId,
+				tabId: tab.tabId,
+				readablePath: usernameInputPath,
+			},
+		);
+
+		expect(typeof result.snapshotId).toBe("string");
+		expect(result.pageNumber).toBe(1);
+		expect(typeof result.data).toBe("string");
+		// outerHTML of the username <input> — starts with a tag and carries its
+		// placeholder attribute.
+		expect(result.data.startsWith("<")).toBe(true);
+		expect(result.data).toContain("Enter username");
+	});
+
+	test("readable-element-html resource matches the tool output", async ({
+		testAppPage,
+		mcpClientPage,
+	}) => {
+		await testAppPage.navigateToFormTest();
+
+		const tab = await mcpClientPage.waitForTabByUrl(
+			testAppPage.page,
+			"form-test",
+		);
+		const tabUri = await mcpClientPage.waitForTabUriByUrl(
+			testAppPage.page,
+			"form-test",
+		);
+
+		const elements = await mcpClientPage.readAllSnapshotElements(tabUri);
+		const usernameInputPath = elements.find(
+			(el) => el[1] === "input" && el[2]?.includes("Enter username"),
+		)?.[0];
+		expectToBeDefined(usernameInputPath);
+
+		const toolResult = await mcpClientPage.callToolJson<
+			SnapshotResultJson<string>
+		>("getReadableElementHtml", {
+			browserId: tab.browserId,
+			tabId: tab.tabId,
+			readablePath: usernameInputPath,
+		});
+
+		const resourceText = await mcpClientPage.readResourceText(
+			`${tabUri}/readable-element-html/${usernameInputPath}`,
+		);
+		const resourceResult = JSON.parse(
+			resourceText,
+		) as SnapshotResultJson<string>;
+
+		expect(resourceResult.data).toBe(toolResult.data);
+		expect(resourceResult.totalPages).toBe(toolResult.totalPages);
+	});
+});

--- a/apps/ext-e2e/src/tests/readable-element-values.spec.ts
+++ b/apps/ext-e2e/src/tests/readable-element-values.spec.ts
@@ -1,0 +1,127 @@
+import { expect, test } from "../fixtures/ext-test";
+import { expectToBeDefined } from "../test-utils/assert-defined";
+
+type SnapshotResultJson<T> = {
+	snapshotId: string;
+	pageNumber: number;
+	nextPageNumber: number | null;
+	hasNextPage: boolean;
+	totalPages: number;
+	data: T;
+};
+
+// ReadableElementRecord as serialized over MCP: [path, role, text, value?].
+// The optional 4th element is present only when the element has a current
+// form value (text inputs/textarea/select) or is a checked checkbox/radio.
+type ElementTuple = [
+	string,
+	string,
+	string,
+	string?,
+];
+
+test.describe("Readable element values", () => {
+	test.beforeEach(async ({ mcpClientPage }) => {
+		test.setTimeout(30000);
+		await mcpClientPage.startServer();
+		await mcpClientPage.connect();
+		await mcpClientPage.waitForBrowsers();
+	});
+
+	test('checked checkbox surfaces value "checked"', async ({
+		testAppPage,
+		mcpClientPage,
+	}) => {
+		await testAppPage.navigateToFormTest();
+
+		const tab = await mcpClientPage.waitForTabByUrl(
+			testAppPage.page,
+			"form-test",
+		);
+
+		const result = await mcpClientPage.callToolJson<
+			SnapshotResultJson<ElementTuple[]>
+		>("getReadableElements", {
+			browserId: tab.browserId,
+			tabId: tab.tabId,
+		});
+
+		const subscribe = result.data.find(
+			(el) => el[1] === "input" && el[2]?.includes("Subscribe to newsletter"),
+		);
+		expectToBeDefined(subscribe);
+		expect(subscribe.length).toBe(4);
+		expect(subscribe[3]).toBe("checked");
+	});
+
+	test("unchecked checkbox and untouched input omit the value (3-tuple)", async ({
+		testAppPage,
+		mcpClientPage,
+	}) => {
+		await testAppPage.navigateToFormTest();
+
+		const tab = await mcpClientPage.waitForTabByUrl(
+			testAppPage.page,
+			"form-test",
+		);
+
+		const result = await mcpClientPage.callToolJson<
+			SnapshotResultJson<ElementTuple[]>
+		>("getReadableElements", {
+			browserId: tab.browserId,
+			tabId: tab.tabId,
+		});
+
+		const marketing = result.data.find(
+			(el) => el[1] === "input" && el[2]?.includes("Receive marketing emails"),
+		);
+		expectToBeDefined(marketing);
+		expect(marketing.length).toBe(3);
+
+		const email = result.data.find(
+			(el) => el[1] === "input" && el[2]?.includes("Enter email"),
+		);
+		expectToBeDefined(email);
+		expect(email.length).toBe(3);
+	});
+
+	test("filled input value appears as the 4th tuple element", async ({
+		testAppPage,
+		mcpClientPage,
+	}) => {
+		await testAppPage.navigateToFormTest();
+
+		const tab = await mcpClientPage.waitForTabByUrl(
+			testAppPage.page,
+			"form-test",
+		);
+		const tabUri = await mcpClientPage.waitForTabUriByUrl(
+			testAppPage.page,
+			"form-test",
+		);
+
+		const elements = await mcpClientPage.readAllSnapshotElements(tabUri);
+		const usernameInputPath = elements.find(
+			(el) => el[1] === "input" && el[2]?.includes("Enter username"),
+		)?.[0];
+		expectToBeDefined(usernameInputPath);
+
+		await mcpClientPage.callTool("fillTextToElement", {
+			...tab,
+			readablePath: usernameInputPath,
+			value: "testuser123",
+		});
+
+		const result = await mcpClientPage.callToolJson<
+			SnapshotResultJson<ElementTuple[]>
+		>("getReadableElements", {
+			browserId: tab.browserId,
+			tabId: tab.tabId,
+		});
+
+		const username = result.data.find((el) => el[0] === usernameInputPath);
+		expectToBeDefined(username);
+		expect(username.length).toBe(4);
+		expect(username[3]).toBe("testuser123");
+	});
+});

--- a/apps/ext-e2e/src/tests/resource-fallback-tools.spec.ts
+++ b/apps/ext-e2e/src/tests/resource-fallback-tools.spec.ts
@@ -200,6 +200,7 @@ test.describe("Resource Fallback Tools", () => {
 						string,
 						string,
 						string,
+						string?,
 					][]
 				>
 			>("getReadableElements", {
@@ -214,10 +215,16 @@ test.describe("Resource Fallback Tools", () => {
 
 			const tuple = result.data[0];
 			expect(Array.isArray(tuple)).toBe(true);
-			expect(tuple.length).toBe(3);
+			// 3 elements normally; an optional 4th (value) is present only when
+			// the element has a current form value.
+			expect(tuple.length).toBeGreaterThanOrEqual(3);
+			expect(tuple.length).toBeLessThanOrEqual(4);
 			expect(typeof tuple[0]).toBe("string");
 			expect(typeof tuple[1]).toBe("string");
 			expect(typeof tuple[2]).toBe("string");
+			if (tuple.length === 4) {
+				expect(typeof tuple[3]).toBe("string");
+			}
 		});
 
 		test("element paths work with interaction tools", async ({
@@ -267,6 +274,7 @@ test.describe("Resource Fallback Tools", () => {
 						string,
 						string,
 						string,
+						string?,
 					][]
 				>
 			>("getReadableElements", {
@@ -282,6 +290,7 @@ test.describe("Resource Fallback Tools", () => {
 					string,
 					string,
 					string,
+					string?,
 				][]
 			>;
 
@@ -292,6 +301,7 @@ test.describe("Resource Fallback Tools", () => {
 				expect(toolResult.data[i][0]).toBe(resourceResult.data[i][0]);
 				expect(toolResult.data[i][1]).toBe(resourceResult.data[i][1]);
 				expect(toolResult.data[i][2]).toBe(resourceResult.data[i][2]);
+				expect(toolResult.data[i][3]).toBe(resourceResult.data[i][3]);
 			}
 		});
 	});
@@ -314,6 +324,7 @@ test.describe("Resource Fallback Tools", () => {
 						string,
 						string,
 						string,
+						string?,
 					][]
 				>
 			>("getReadableElements", {
@@ -330,6 +341,7 @@ test.describe("Resource Fallback Tools", () => {
 						string,
 						string,
 						string,
+						string?,
 					][]
 				>
 			>("getSnapshotPage", {

--- a/packages/core-extension/src/core/extension-tool-call.ts
+++ b/packages/core-extension/src/core/extension-tool-call.ts
@@ -167,4 +167,22 @@ export class ToolCallHandlersUseCase implements ExtensionToolCallInputPort {
 			throw error;
 		}
 	};
+
+	getElementHtml = async (tabId: string, readablePath: string) => {
+		this.logger.info(
+			`Getting element HTML from tab: ${tabId}, path: ${readablePath}`,
+		);
+
+		try {
+			const html = await this.browserDriver.getElementHtmlByReadablePath(
+				tabId,
+				readablePath,
+			);
+			this.logger.info("Retrieved element HTML successfully");
+			return html;
+		} catch (error) {
+			this.logger.error("Failed to get element HTML", error);
+			throw error;
+		}
+	};
 }

--- a/packages/core-extension/src/output-ports/browser-driver.ts
+++ b/packages/core-extension/src/output-ports/browser-driver.ts
@@ -47,6 +47,10 @@ export interface BrowserDriverOutputPort {
 		tabId: string,
 		readableTreePath: string,
 	): Promise<void>;
+	getElementHtmlByReadablePath(
+		tabId: string,
+		readableTreePath: string,
+	): Promise<string>;
 	showHumanHint(
 		tabId: string,
 		params: ShowHumanHintParams,

--- a/packages/core-extension/src/types/extension-tools.ts
+++ b/packages/core-extension/src/types/extension-tools.ts
@@ -27,6 +27,7 @@ export interface TabSpecificTool {
 	loadTabContext(tabId: string): Promise<TabContext>;
 	getReadableElements: (tabId: string) => Promise<ReadableElementRecord[]>;
 	getReadableText: (tabId: string) => Promise<string>;
+	getElementHtml: (tabId: string, readablePath: string) => Promise<string>;
 	getSelection(tabId: string): Promise<Selection>;
 	hitEnterOnCoordinates(tabId: string, x: number, y: number): Promise<void>;
 	hitEnterOnElement(tabId: string, readablePath: string): Promise<void>;

--- a/packages/core-extension/src/types/readable-element-record.ts
+++ b/packages/core-extension/src/types/readable-element-record.ts
@@ -2,4 +2,5 @@ export type ReadableElementRecord = [
 	path: string,
 	accessibleRole: string,
 	accessibleText: string,
+	value?: string,
 ];

--- a/packages/core-server/src/core/mcp-descriptions.ts
+++ b/packages/core-server/src/core/mcp-descriptions.ts
@@ -221,14 +221,25 @@ export class McpDescriptionsUseCases implements McpDescriptionsInputPort {
 		].join("\n");
 	};
 
+	getReadableElementHtmlInstruction = (): string => {
+		return [
+			"Get the outerHTML of a single element by readablePath.",
+			"When: you need the exact markup (attributes, classes, nested structure) of one element — equivalent to reading {tabUri}/readable-element-html/<readablePath>.",
+			"How: get readablePath from a readable-elements tuple (first field); browserId and tabId from getContext or bk:///context.",
+			"Requires: browserId, tabId, readablePath (dot-separated tree index e.g. 0.2.1, not a CSS selector).",
+			"Returns: { snapshotId, data (HTML), hasNextPage, nextPageNumber, totalPages }.",
+			"Pagination: if hasNextPage is true, call getSnapshotPage with the returned snapshotId, type readable-element-html, and nextPageNumber.",
+		].join("\n");
+	};
+
 	getSnapshotPageInstruction = (): string => {
 		return [
-			"Get a continuation page for a readable-text or readable-elements snapshot.",
-			"When: a previous getReadableText or getReadableElements call returned hasNextPage=true.",
+			"Get a continuation page for a readable-text, readable-elements, or readable-element-html snapshot.",
+			"When: a previous getReadableText, getReadableElements, or getReadableElementHtml call returned hasNextPage=true.",
 			"How: use the snapshotId and nextPageNumber from the previous response.",
-			"Requires: snapshotId, type (readable-text | readable-elements), pageNumber.",
+			"Requires: snapshotId, type (readable-text | readable-elements | readable-element-html), pageNumber.",
 			"Returns: same shape as the original call — { snapshotId, data, hasNextPage, nextPageNumber, totalPages }.",
-			"Avoid: calling without first fetching page 1 via getReadableText or getReadableElements.",
+			"Avoid: calling without first fetching page 1 via getReadableText, getReadableElements, or getReadableElementHtml.",
 		].join("\n");
 	};
 
@@ -248,7 +259,8 @@ export class McpDescriptionsUseCases implements McpDescriptionsInputPort {
 			"bk:///browsers/<shortId>/tabs/<tabId> — tab metadata (shortId is the browserId)",
 			"bk:///browsers/<shortId>/tabs/<tabId>/readable-text — readable text snapshot (page 1 only)",
 			"bk:///browsers/<shortId>/tabs/<tabId>/readable-elements — readable elements snapshot (page 1 only)",
-			"bk:///snapshot-types/<type>/snapshots/<snapshotId>/pages/<N> — page 2+ for both readable-text and readable-elements (use snapshotId from page 1)",
+			"bk:///browsers/<shortId>/tabs/<tabId>/readable-element-html/<readablePath> — outerHTML of one element (page 1 only)",
+			"bk:///snapshot-types/<type>/snapshots/<snapshotId>/pages/<N> — page 2+ for readable-text, readable-elements, and readable-element-html (use snapshotId from page 1)",
 		].join("\n");
 	};
 
@@ -284,6 +296,18 @@ export class McpDescriptionsUseCases implements McpDescriptionsInputPort {
 			"Returns JSON with snapshotId, data ([path, role, text, value?] tuples), hasNextPage, nextPageNumber, totalPages.",
 			"path is a dot-separated tree index (e.g. 0.2.1) — use as readablePath, not a CSS selector.",
 			"Page 2+: bk:///snapshot-types/readable-elements/snapshots/<snapshotId>/pages/<nextPageNumber>.",
+		].join(" ");
+	};
+
+	tabReadableElementHtmlDescription = (
+		tabId: string,
+		readablePath: string,
+	): string => {
+		return [
+			`outerHTML of element ${readablePath} in tab ${tabId}.`,
+			"Returns JSON with snapshotId, data (HTML), hasNextPage, nextPageNumber, totalPages.",
+			"readablePath is a dot-separated tree index (e.g. 0.2.1) from a readable-elements tuple, not a CSS selector.",
+			"Page 2+: bk:///snapshot-types/readable-element-html/snapshots/<snapshotId>/pages/<nextPageNumber>.",
 		].join(" ");
 	};
 

--- a/packages/core-server/src/core/mcp-descriptions.ts
+++ b/packages/core-server/src/core/mcp-descriptions.ts
@@ -13,7 +13,7 @@ export class McpDescriptionsUseCases implements McpDescriptionsInputPort {
 			"3. Read its ids: browserId (browsers[].browserId), windowId and tabId (browsers[].tabs[].windowId / .id); copy tabUri and extensionInfo.manifestVersion verbatim",
 			"4. resources/read -> {tabUri}/readable-elements",
 			"5. If hasNextPage, read bk:///snapshot-types/readable-elements/snapshots/{snapshotId}/pages/{nextPageNumber}",
-			"6. Filter data tuples [path, role, text] by role and text; use path (e.g. 0.2.1) as readablePath",
+			'6. Filter data tuples [path, role, text, value?] by role and text; use path (e.g. 0.2.1) as readablePath. value is appended only when the element has a current form value (text inputs/textarea/select) or is a checked checkbox/radio ("checked").',
 			"7. Call tool with { browserId, windowId, tabId, ... }; always check structuredContent.ok — if false, re-read elements or showHumanHint",
 			"",
 			"Quick start (tools — for clients without resource support):",
@@ -42,7 +42,7 @@ export class McpDescriptionsUseCases implements McpDescriptionsInputPort {
 			"- Native <input> date/time/color pickers: fillTextToElement with the exact value format (see fillTextToElement).",
 			"- Native <select>, by shape, verifying via re-read after each step. Listbox (multiple or size>1) shows options inline: clickOnElement the option, else MV2 invokeJsFn (set option.selected or .value/.selectedIndex, dispatch a bubbling change). Single-line dropdown (size=1) has a native popup that ignores synthetic clicks: MV2 invokeJsFn (set .value/.selectedIndex, dispatch change); MV3 best-effort clickOnElement select then option, then showHumanHint if unchanged.",
 			"- Range slider: try fillTextToElement with the numeric value (subject to min/max/step); if it clamps or fails, MV2 -> invokeJsFn (set .value, dispatch input + change), MV3 -> showHumanHint.",
-			"- Checkbox/radio: clickOnElement toggles it. Checked state is not in the [path, role, text] tuples, so confirm via getReadableText and avoid re-clicking a box already in the desired state.",
+			'- Checkbox/radio: clickOnElement toggles it. Checked state appears as the optional 4th tuple value "checked" (absent when unchecked), so check the tuple and avoid re-clicking a box already in the desired state.',
 			"- File input (<input type=file>): cannot be set by tools (browser security). Use showHumanHint with the fill action to ask the user to pick the file.",
 			"",
 			"Constraints:",
@@ -102,7 +102,7 @@ export class McpDescriptionsUseCases implements McpDescriptionsInputPort {
 		return [
 			"Click an element by readablePath.",
 			"When: primary click method on MV2 and MV3.",
-			"How: read {tabUri}/readable-elements; filter [path, role, text] tuples by role and text; copy path exactly (e.g. 0.2.1) — not a CSS selector.",
+			"How: read {tabUri}/readable-elements; filter [path, role, text, value?] tuples by role and text; copy path exactly (e.g. 0.2.1) — not a CSS selector.",
 			"Custom dropdown/combobox/datepicker: click the trigger to open it, then re-read readable-elements and click the option/day cell. Native <select>: clicking an option can work for listbox selects (multiple or size>1) but single-line dropdowns use a native popup that ignores synthetic clicks — those need invokeJsFn (MV2) or showHumanHint (MV3). Verify by re-reading and escalate. See Complex inputs.",
 			"Requires: browserId, windowId, tabId, readablePath.",
 			"Returns: ok=true on success; on ok=false re-read readable-elements and pick a fresh path.",
@@ -114,7 +114,7 @@ export class McpDescriptionsUseCases implements McpDescriptionsInputPort {
 		return [
 			"Type text into an <input> or <textarea> by readablePath.",
 			"When: primary fill method on MV2 and MV3. Also handles native <input> date/time/datetime-local/month/color when value is in the exact format (date YYYY-MM-DD, time HH:MM, datetime-local YYYY-MM-DDTHH:MM, month YYYY-MM, color #rrggbb).",
-			"How: readablePath from first element of [path, role, text] tuple in readable-elements; submit via clickOnElement on submit button or hitEnterOnElement.",
+			"How: readablePath from first element of [path, role, text, value?] tuple in readable-elements; submit via clickOnElement on submit button or hitEnterOnElement.",
 			"Requires: browserId, windowId, tabId, readablePath, value.",
 			"Returns: ok=true on success; on ok=false re-read readable-elements and pick a fresh path.",
 			"Avoid: CSS selectors as readablePath; stale paths after DOM changes. Does not work on contenteditable rich-text editors (MV2 invokeJsFn instead), native <select>, or custom popup dropdowns/datepickers — use the strategy ladder under Complex inputs in server instructions.",
@@ -211,11 +211,11 @@ export class McpDescriptionsUseCases implements McpDescriptionsInputPort {
 
 	getReadableElementsInstruction = (): string => {
 		return [
-			"Get interactive elements of a tab as [path, role, text] tuples.",
+			"Get interactive elements of a tab as [path, role, text, value?] tuples.",
 			"When: you need element paths for clickOnElement/fillTextToElement — equivalent to reading {tabUri}/readable-elements resource.",
 			"How: browserId and tabId from getContext or bk:///context.",
 			"Requires: browserId, tabId.",
-			"Returns: { snapshotId, data ([path, role, text] tuples), hasNextPage, nextPageNumber, totalPages }.",
+			"Returns: { snapshotId, data ([path, role, text, value?] tuples), hasNextPage, nextPageNumber, totalPages }.",
 			"path is a dot-separated tree index (e.g. 0.2.1) — use as readablePath in interaction tools.",
 			"Pagination: if hasNextPage is true, call getSnapshotPage with the returned snapshotId and nextPageNumber.",
 		].join("\n");
@@ -281,7 +281,7 @@ export class McpDescriptionsUseCases implements McpDescriptionsInputPort {
 	tabReadableElementsDescription = (tabId: string): string => {
 		return [
 			`Snapshot interactive elements for tab ${tabId}.`,
-			"Returns JSON with snapshotId, data ([path, role, text] tuples), hasNextPage, nextPageNumber, totalPages.",
+			"Returns JSON with snapshotId, data ([path, role, text, value?] tuples), hasNextPage, nextPageNumber, totalPages.",
 			"path is a dot-separated tree index (e.g. 0.2.1) — use as readablePath, not a CSS selector.",
 			"Page 2+: bk:///snapshot-types/readable-elements/snapshots/<snapshotId>/pages/<nextPageNumber>.",
 		].join(" ");

--- a/packages/core-server/src/core/snapshot-content.ts
+++ b/packages/core-server/src/core/snapshot-content.ts
@@ -14,7 +14,16 @@ const SNAPSHOT_CAP = 50;
 
 const snapshotIdGenerator = createPrefixId("snapshot");
 
-type ContentType = "readable-text" | "readable-elements";
+type ContentType =
+	| "readable-text"
+	| "readable-elements"
+	| "readable-element-html";
+
+const elementHtmlCacheKey = (
+	channelId: string,
+	tabId: string,
+	readablePath: string,
+): string => `${channelId}::${tabId}::readable-element-html::${readablePath}`;
 
 interface CachedPages<T> {
 	snapshotId: string;
@@ -175,9 +184,45 @@ export class SnapshotContentUseCases implements SnapshotContentInputPort {
 		);
 	}
 
+	async getReadableElementHtmlPage(
+		channelId: string,
+		tabId: string,
+		readablePath: string,
+		pageNumber = 1,
+	): Promise<SnapshotResult<string>> {
+		const key = elementHtmlCacheKey(channelId, tabId, readablePath);
+
+		if (pageNumber === 1) {
+			const html = await this.fetchElementHtml(channelId, tabId, readablePath);
+			const pages = splitText(html, PAGE_SIZE_CHARS);
+			const snapshotId = snapshotIdGenerator.generate();
+			const cached: CachedPages<string> = {
+				snapshotId,
+				channelId,
+				tabId,
+				type: "readable-element-html",
+				pages,
+				totalPages: pages.length,
+			};
+			this.cache.set(key, cached);
+			this.cacheBySnapshotId.set(snapshotId, cached);
+			this.evictIfOverCap();
+			this.logger.verbose("Cached readable-element-html", {
+				channelId,
+				tabId,
+				readablePath,
+				totalPages: cached.totalPages,
+				snapshotId: cached.snapshotId,
+			});
+			return buildResult(cached, 1);
+		}
+
+		return this.getFromCache<string>(key, pageNumber, "readable-element-html");
+	}
+
 	async getSnapshotPage(
 		snapshotId: string,
-		type: "readable-text" | "readable-elements",
+		type: ContentType,
 		pageNumber: number,
 	): Promise<SnapshotResult<any>> {
 		const cached = this.cacheBySnapshotId.get(snapshotId);
@@ -203,6 +248,14 @@ export class SnapshotContentUseCases implements SnapshotContentInputPort {
 		if (tabId) {
 			this.cache.delete(cacheKey(channelId, tabId, "readable-text"));
 			this.cache.delete(cacheKey(channelId, tabId, "readable-elements"));
+			// Element-html entries are keyed per readablePath, so purge by prefix.
+			const elementHtmlPrefix = `${channelId}::${tabId}::readable-element-html::`;
+			for (const [key, cached] of this.cache.entries()) {
+				if (key.startsWith(elementHtmlPrefix)) {
+					this.cacheBySnapshotId.delete(cached.snapshotId);
+					this.cache.delete(key);
+				}
+			}
 			this.logger.verbose("Invalidated latest-snapshot pointer for tab", {
 				channelId,
 				tabId,
@@ -280,6 +333,22 @@ export class SnapshotContentUseCases implements SnapshotContentInputPort {
 			] as never,
 			extraArgs: {},
 		}) as Promise<ReadableElementRecord[]>;
+	}
+
+	private async fetchElementHtml(
+		channelId: string,
+		tabId: string,
+		readablePath: string,
+	): Promise<string> {
+		const rpcClient = this.getRpcClient(channelId);
+		return rpcClient.call({
+			method: "getElementHtml" as keyof ExtensionToolCallInputPort,
+			args: [
+				tabId,
+				readablePath,
+			] as never,
+			extraArgs: {},
+		}) as Promise<string>;
 	}
 
 	private getRpcClient(channelId: string) {

--- a/packages/core-server/src/input-ports/mcp-descriptions.ts
+++ b/packages/core-server/src/input-ports/mcp-descriptions.ts
@@ -20,6 +20,7 @@ export interface McpDescriptionsInputPort {
 	getContextInstruction(): string;
 	getReadableTextInstruction(): string;
 	getReadableElementsInstruction(): string;
+	getReadableElementHtmlInstruction(): string;
 	getSnapshotPageInstruction(): string;
 
 	// Resource descriptions
@@ -37,6 +38,10 @@ export interface McpDescriptionsInputPort {
 	): string;
 	tabReadableTextDescription(tabId: string): string;
 	tabReadableElementsDescription(tabId: string): string;
+	tabReadableElementHtmlDescription(
+		tabId: string,
+		readablePath: string,
+	): string;
 }
 
 export const McpDescriptionsInputPort = Symbol.for("McpDescriptionsInputPort");

--- a/packages/core-server/src/input-ports/snapshot-content.ts
+++ b/packages/core-server/src/input-ports/snapshot-content.ts
@@ -24,6 +24,18 @@ export interface SnapshotContentInputPort {
 	): Promise<SnapshotResult<ReadableElementRecord[]>>;
 
 	/**
+	 * Same as `getReadableTextPage` but for the `outerHTML` of the single element
+	 * identified by `readablePath` (the dot-separated tree index from a
+	 * readable-elements tuple).
+	 */
+	getReadableElementHtmlPage(
+		channelId: string,
+		tabId: string,
+		readablePath: string,
+		pageNumber?: number,
+	): Promise<SnapshotResult<string>>;
+
+	/**
 	 * Evicts cached pages. When `tabId` is provided only entries for that tab
 	 * are removed; otherwise all entries for the browser channel are cleared.
 	 */
@@ -35,7 +47,7 @@ export interface SnapshotContentInputPort {
 	 */
 	getSnapshotPage(
 		snapshotId: string,
-		type: "readable-text" | "readable-elements",
+		type: "readable-text" | "readable-elements" | "readable-element-html",
 		pageNumber: number,
 	): Promise<SnapshotResult<any>>;
 }

--- a/packages/extension-driven-browser-driver/src/services/driven-browser-driver-base.ts
+++ b/packages/extension-driven-browser-driver/src/services/driven-browser-driver-base.ts
@@ -149,6 +149,24 @@ export abstract class DrivenBrowserDriverBase
 		});
 	};
 
+	getElementHtmlByReadablePath = (
+		tabId: string,
+		readablePath: string,
+	): Promise<string> => {
+		this.logger.verbose(
+			`Getting element HTML by readable path: ${readablePath} in tab: ${tabId}`,
+		);
+		return this.tabRpcService.tabRpcClient.call({
+			method: "dom.getElementHtmlByReadablePath",
+			args: [
+				readablePath,
+			],
+			extraArgs: {
+				tabId,
+			},
+		});
+	};
+
 	focusOnCoordinates = (tabId: string, x: number, y: number): Promise<void> => {
 		this.logger.verbose(
 			`Focusing on coordinates (${x}, ${y}) in tab: ${tabId}`,

--- a/packages/extension-driven-browser-driver/src/services/tab-dom-tools.ts
+++ b/packages/extension-driven-browser-driver/src/services/tab-dom-tools.ts
@@ -130,6 +130,22 @@ export class TabDomTools {
 		this.logger.verbose("Click on element completed");
 	};
 
+	getElementHtmlByReadablePath = async (
+		readablePath: string,
+	): Promise<string> => {
+		this.logger.info(`Getting HTML for element at path: ${readablePath}`);
+
+		const element = this.contextStore.getElementFromPath(readablePath);
+		if (!element) {
+			this.logger.warn(`Element not found at path: ${readablePath}`);
+			throw new Error(`Element not found at path: ${readablePath}`);
+		}
+
+		const html = element.outerHTML;
+		this.logger.verbose(`Retrieved element HTML (${html.length} characters)`);
+		return html;
+	};
+
 	fillTextToElementByReadablePath = async (
 		readablePath: string,
 		value: string,

--- a/packages/extension-driven-browser-driver/src/types/readable-element-record.ts
+++ b/packages/extension-driven-browser-driver/src/types/readable-element-record.ts
@@ -2,4 +2,5 @@ export type ReadableElementRecord = [
 	path: string,
 	accessibleRole: string,
 	accessibleText: string,
+	value?: string,
 ];

--- a/packages/extension-driven-browser-driver/src/utils/to-element-records.ts
+++ b/packages/extension-driven-browser-driver/src/utils/to-element-records.ts
@@ -3,9 +3,34 @@ import { treeToPathValueArray } from "@mcp-browser-kit/core-utils/tree";
 import type { ReadableElementRecord } from "../types";
 
 /**
+ * Extracts the current form value of an element, if it has one.
+ * @returns The element's value (or "checked" for checked checkboxes/radios),
+ *   or "" for elements without a meaningful value.
+ */
+function getElementValue(element: globalThis.Element): string {
+	if (element instanceof globalThis.HTMLInputElement) {
+		if (element.type === "checkbox" || element.type === "radio") {
+			return element.checked ? "checked" : "";
+		}
+		return element.value;
+	}
+
+	if (
+		element instanceof globalThis.HTMLTextAreaElement ||
+		element instanceof globalThis.HTMLSelectElement
+	) {
+		return element.value;
+	}
+
+	return "";
+}
+
+/**
  * Converts a tree of DOM elements to an array of ReadableElementRecords
  * @param tree - TreeNode structure containing DOM elements
- * @returns Array of ReadableElementRecord objects with path, accessibleRole, and accessibleText
+ * @returns Array of ReadableElementRecord tuples with path, accessibleRole,
+ *   accessibleText, and an optional value (appended only when the element has
+ *   a non-empty form value)
  */
 export function toElementRecords(
 	tree: TreeNode<globalThis.Element>,
@@ -28,10 +53,19 @@ export function toElementRecords(
 			element.textContent?.trim() ??
 			"";
 
-		return [
+		const record: ReadableElementRecord = [
 			path,
 			accessibleRole,
 			accessibleText,
 		];
+
+		// Append the current form value only when present, keeping the tuple at
+		// 3 elements for everything without a value.
+		const value = getElementValue(element);
+		if (value) {
+			record.push(value);
+		}
+
+		return record;
 	});
 }

--- a/packages/server-driving-mcp-server/src/services/browser-resources.ts
+++ b/packages/server-driving-mcp-server/src/services/browser-resources.ts
@@ -496,6 +496,24 @@ export class BrowserResources {
 			};
 		}
 
+		if (parsed.type === "tab-readable-element-html") {
+			const result = await this.snapshotContent.getReadableElementHtmlPage(
+				parsed.channelId,
+				parsed.tabId,
+				parsed.readablePath,
+				1,
+			);
+			return {
+				contents: [
+					{
+						uri: uri.toString(),
+						mimeType: "application/json",
+						text: JSON.stringify(result, null, 2),
+					},
+				],
+			};
+		}
+
 		const windowId = findWindowIdForTab(entry.snapshot, parsed.tabId);
 		const contentChangedAt =
 			entry.snapshot.contentChangedAt?.[parsed.tabId] ?? undefined;

--- a/packages/server-driving-mcp-server/src/services/resource-fallback-tools.ts
+++ b/packages/server-driving-mcp-server/src/services/resource-fallback-tools.ts
@@ -14,7 +14,11 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { inject, injectable } from "inversify";
 import { over } from "ok-value-error-reason";
 import { findWindowIdForTab, tabBkUri } from "../utils/browser-resource-uris";
-import { snapshotPageSchema, tabReadRefSchema } from "../utils/tool-schemas";
+import {
+	snapshotPageSchema,
+	tabReadableElementHtmlSchema,
+	tabReadRefSchema,
+} from "../utils/tool-schemas";
 
 /**
  * Fallback MCP tools that expose the same data as the bk:/// resources.
@@ -41,6 +45,7 @@ export class ResourceFallbackTools {
 		this.registerGetContext(server);
 		this.registerGetReadableText(server);
 		this.registerGetReadableElements(server);
+		this.registerGetReadableElementHtml(server);
 		this.registerGetSnapshotPage(server);
 	}
 
@@ -183,6 +188,71 @@ export class ResourceFallbackTools {
 					this.logger.error("Failed to get readable elements", {
 						browserId,
 						tabId,
+						reason: overResult.reason,
+					});
+					return {
+						content: [
+							{
+								type: "text" as const,
+								text: JSON.stringify(
+									{
+										ok: false,
+										reason: String(overResult.reason),
+									},
+									null,
+									2,
+								),
+							},
+						],
+					};
+				}
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: JSON.stringify(overResult.value, null, 2),
+						},
+					],
+				};
+			},
+		);
+	}
+
+	private registerGetReadableElementHtml(server: McpServer): void {
+		this.logger.verbose("Registering tool: getReadableElementHtml");
+		server.registerTool(
+			"getReadableElementHtml",
+			{
+				title: "Get readable element HTML",
+				description: this.mcpDescriptions.getReadableElementHtmlInstruction(),
+				inputSchema: tabReadableElementHtmlSchema,
+				annotations: {
+					readOnlyHint: true,
+					openWorldHint: true,
+				},
+			},
+			async ({ browserId, tabId, readablePath }) => {
+				this.logger.info("Executing getReadableElementHtml", {
+					browserId,
+					tabId,
+					readablePath,
+				});
+				const overResult = await over(async () => {
+					const channelId = this.resolveChannelId(browserId);
+					return this.snapshotContent.getReadableElementHtmlPage(
+						channelId,
+						tabId,
+						readablePath,
+						1,
+					);
+				});
+
+				if (!overResult.ok) {
+					this.logger.error("Failed to get readable element HTML", {
+						browserId,
+						tabId,
+						readablePath,
 						reason: overResult.reason,
 					});
 					return {

--- a/packages/server-driving-mcp-server/src/utils/browser-resource-uris.ts
+++ b/packages/server-driving-mcp-server/src/utils/browser-resource-uris.ts
@@ -57,9 +57,17 @@ export const tabReadableElementsBkUri = (
 ): string =>
 	`${BK_URI_PREFIX}browsers/${shortChannelId(channelId)}/tabs/${tabId}/readable-elements`;
 
+/** `bk:///browsers/<shortId>/tabs/<tabId>/readable-element-html/<readablePath>` */
+export const tabReadableElementHtmlBkUri = (
+	channelId: string,
+	tabId: string,
+	readablePath: string,
+): string =>
+	`${BK_URI_PREFIX}browsers/${shortChannelId(channelId)}/tabs/${tabId}/readable-element-html/${readablePath}`;
+
 /** `bk:///snapshot-types/<type>/snapshots/<snapshotId>/pages/<page>` */
 export const snapshotPageBkUri = (
-	type: "readable-text" | "readable-elements",
+	type: "readable-text" | "readable-elements" | "readable-element-html",
 	snapshotId: string,
 	page: number,
 ): string =>
@@ -88,8 +96,17 @@ export type ParsedBkResource =
 			tabId: string;
 	  }
 	| {
+			type: "tab-readable-element-html";
+			channelId: string;
+			tabId: string;
+			readablePath: string;
+	  }
+	| {
 			type: "snapshot-page";
-			contentType: "readable-text" | "readable-elements";
+			contentType:
+				| "readable-text"
+				| "readable-elements"
+				| "readable-element-html";
 			snapshotId: string;
 			pageNumber: number;
 	  };
@@ -116,10 +133,13 @@ export const parseBkResourceId = (
 ): ParsedBkResource | undefined => {
 	if (resourceId.startsWith("snapshot-types/")) {
 		const match = resourceId.match(
-			/^snapshot-types\/(readable-text|readable-elements)\/snapshots\/([^/]+)\/pages\/(\d+)$/,
+			/^snapshot-types\/(readable-text|readable-elements|readable-element-html)\/snapshots\/([^/]+)\/pages\/(\d+)$/,
 		);
 		if (match) {
-			const contentType = match[1] as "readable-text" | "readable-elements";
+			const contentType = match[1] as
+				| "readable-text"
+				| "readable-elements"
+				| "readable-element-html";
 			const snapshotId = match[2];
 			const pageNumber = Number(match[3]);
 			if (pageNumber >= 1) {
@@ -180,6 +200,18 @@ export const parseBkResourceId = (
 				channelId,
 				tabId,
 			};
+		}
+		const elementHtmlPrefix = "readable-element-html/";
+		if (suffix.startsWith(elementHtmlPrefix)) {
+			const readablePath = suffix.slice(elementHtmlPrefix.length);
+			if (readablePath) {
+				return {
+					type: "tab-readable-element-html",
+					channelId,
+					tabId,
+					readablePath,
+				};
+			}
 		}
 		return;
 	}

--- a/packages/server-driving-mcp-server/src/utils/tool-schemas.ts
+++ b/packages/server-driving-mcp-server/src/utils/tool-schemas.ts
@@ -64,6 +64,16 @@ export const readableElementTextInputSchema = {
 	value: z.string().describe("Text to enter into the input field"),
 };
 
+/** Identifies a single element for an HTML read: browserId + tabId + readablePath. */
+export const tabReadableElementHtmlSchema = {
+	...tabReadRefSchema,
+	readablePath: z
+		.string()
+		.describe(
+			"Dot-separated tree path (e.g. 0.2.1) — first element of a [path, role, text, value?] tuple from readable-elements; not a CSS selector",
+		),
+};
+
 export const invokeJsFnSchema = {
 	...tabRefSchema,
 	fnBodyCode: z
@@ -194,8 +204,11 @@ export const snapshotPageSchema = {
 		.enum([
 			"readable-text",
 			"readable-elements",
+			"readable-element-html",
 		])
-		.describe("Content type: readable-text or readable-elements"),
+		.describe(
+			"Content type: readable-text, readable-elements, or readable-element-html",
+		),
 	pageNumber: z
 		.number()
 		.int()


### PR DESCRIPTION
Append the element's current form value as an optional 4th tuple element ([path, role, text, value?]). The value is the .value of text inputs, textareas, and selects, or "checked" for a checked checkbox/radio, and is omitted (3-tuple) when empty — keeping output compact for the common case.

- Add value? to both ReadableElementRecord type definitions
- Extract the value in toElementRecords via a getElementValue helper
- Update MCP tool/resource descriptions to document the 4th element
- Add e2e coverage (form-test checkboxes + readable-element-values.spec)
- chore: make mcp-inspector task depend on build