### PR TITLE
feat: add scrollPage tool for viewport scrolling

### DIFF
--- a/apps/ext-e2e-test-app/src/components/screens/scroll-test-screen.tsx
+++ b/apps/ext-e2e-test-app/src/components/screens/scroll-test-screen.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from "react";
+import { TestScreenLayout } from "../layouts/test-screen-layout";
+
+export function meta() {
+	return [
+		{
+			title: "Scroll Test",
+		},
+	];
+}
+
+export function ScrollTestScreen() {
+	const [scrollX, setScrollX] = useState(0);
+	const [scrollY, setScrollY] = useState(0);
+
+	useEffect(() => {
+		const handleScroll = () => {
+			setScrollX(Math.round(window.scrollX));
+			setScrollY(Math.round(window.scrollY));
+		};
+		handleScroll();
+		window.addEventListener("scroll", handleScroll, {
+			passive: true,
+		});
+		return () => window.removeEventListener("scroll", handleScroll);
+	}, []);
+
+	return (
+		<div className="p-5 font-sans">
+			<TestScreenLayout>
+				{/* Fixed readout so the current scroll position is always visible */}
+				<div className="fixed top-2.5 right-2.5 z-50 p-2.5 bg-gray-900 text-white rounded text-sm">
+					<p data-testid="scroll-y" className="m-0">
+						scrollY: {scrollY}
+					</p>
+					<p data-testid="scroll-x" className="m-0">
+						scrollX: {scrollX}
+					</p>
+				</div>
+
+				<h1 data-testid="page-title" className="text-3xl font-bold mb-6">
+					Scroll Test Screen
+				</h1>
+
+				<p className="mb-6">
+					This page overflows both vertically and horizontally so scrollPage can
+					be exercised in every direction.
+				</p>
+
+				{/* Wide block to create horizontal overflow */}
+				<div
+					data-testid="wide-block"
+					className="mb-8 bg-gradient-to-r from-blue-200 to-purple-200 rounded"
+					style={{
+						width: "3000px",
+						height: "120px",
+					}}
+				>
+					<span className="inline-block p-4 font-bold">Far left edge</span>
+					<span
+						data-testid="wide-block-end"
+						className="float-right p-4 font-bold"
+					>
+						Far right edge
+					</span>
+				</div>
+
+				{/* Tall spacer to create vertical overflow */}
+				<div
+					data-testid="tall-block"
+					className="bg-gray-100 rounded"
+					style={{
+						minHeight: "4000px",
+					}}
+				>
+					<span className="inline-block p-4 font-bold">Top of tall block</span>
+					<div
+						className="absolute"
+						style={{
+							top: "3900px",
+						}}
+					>
+						<span data-testid="bottom-marker" className="p-4 font-bold">
+							Bottom of tall block
+						</span>
+					</div>
+				</div>
+			</TestScreenLayout>
+		</div>
+	);
+}

--- a/apps/ext-e2e-test-app/src/pages/scroll-test.tsx
+++ b/apps/ext-e2e-test-app/src/pages/scroll-test.tsx
@@ -1,0 +1,4 @@
+export {
+	meta,
+	ScrollTestScreen as default,
+} from "../components/screens/scroll-test-screen";

--- a/apps/ext-e2e-test-app/src/routes.ts
+++ b/apps/ext-e2e-test-app/src/routes.ts
@@ -8,6 +8,7 @@ const routes = [
 	route("javascript-test", "pages/javascript-test.tsx"),
 	route("fallback-test", "pages/fallback-test.tsx"),
 	route("snapshot-test", "pages/snapshot-test.tsx"),
+	route("scroll-test", "pages/scroll-test.tsx"),
 ] satisfies RouteConfig;
 
 export default routes;

--- a/apps/ext-e2e/src/pages/test-app-page.ts
+++ b/apps/ext-e2e/src/pages/test-app-page.ts
@@ -11,6 +11,7 @@ export class TestAppPage extends BasePage {
 	readonly javascriptTestUrl = `${TEST_APP_BASE_URL}/javascript-test`;
 	readonly fallbackTestUrl = `${TEST_APP_BASE_URL}/fallback-test`;
 	readonly snapshotTestUrl = `${TEST_APP_BASE_URL}/snapshot-test`;
+	readonly scrollTestUrl = `${TEST_APP_BASE_URL}/scroll-test`;
 
 	readonly pageTitle: Locator;
 
@@ -45,6 +46,11 @@ export class TestAppPage extends BasePage {
 
 	async navigateToSnapshotTest() {
 		await this.goto(this.snapshotTestUrl);
+		await super.waitForPageLoad(this.getByTestId("page-title"));
+	}
+
+	async navigateToScrollTest() {
+		await this.goto(this.scrollTestUrl);
 		await super.waitForPageLoad(this.getByTestId("page-title"));
 	}
 
@@ -103,6 +109,13 @@ export class TestAppPage extends BasePage {
 			mousedownCount: this.getByTestId("mousedown-count"),
 			standardButton: this.getByTestId("standard-button"),
 			standardClickCount: this.getByTestId("standard-click-count"),
+		};
+	}
+
+	getScrollTestLocators() {
+		return {
+			scrollY: this.getByTestId("scroll-y"),
+			scrollX: this.getByTestId("scroll-x"),
 		};
 	}
 

--- a/apps/ext-e2e/src/tests/scroll-tools.spec.ts
+++ b/apps/ext-e2e/src/tests/scroll-tools.spec.ts
@@ -1,0 +1,143 @@
+import type { Locator } from "@playwright/test";
+import { expect, test } from "../fixtures/ext-test";
+
+/** Parses the integer rendered in a "scrollX: N" / "scrollY: N" readout. */
+async function readScroll(locator: Locator): Promise<number> {
+	const text = (await locator.textContent()) ?? "";
+	const match = text.match(/-?\d+/);
+	return match ? Number(match[0]) : Number.NaN;
+}
+
+test.describe("Scroll Tools", () => {
+	test.beforeEach(async ({ mcpClientPage }) => {
+		test.setTimeout(30000);
+		await mcpClientPage.startServer();
+		await mcpClientPage.connect();
+		await mcpClientPage.waitForBrowsers();
+	});
+
+	test("scrolls down by ~one viewport when no amount is given", async ({
+		testAppPage,
+		mcpClientPage,
+	}) => {
+		await testAppPage.navigateToScrollTest();
+		const tab = await mcpClientPage.waitForTabByUrl(
+			testAppPage.page,
+			"scroll-test",
+		);
+
+		const locators = testAppPage.getScrollTestLocators();
+		expect(await readScroll(locators.scrollY)).toBe(0);
+
+		const result = await mcpClientPage.callTool("scrollPage", {
+			...tab,
+			direction: "down",
+		});
+		expect(result.structuredContent?.ok).toBe(true);
+
+		await expect.poll(() => readScroll(locators.scrollY)).toBeGreaterThan(100);
+	});
+
+	test("scrolls down by an explicit pixel amount", async ({
+		testAppPage,
+		mcpClientPage,
+	}) => {
+		await testAppPage.navigateToScrollTest();
+		const tab = await mcpClientPage.waitForTabByUrl(
+			testAppPage.page,
+			"scroll-test",
+		);
+
+		const locators = testAppPage.getScrollTestLocators();
+
+		const result = await mcpClientPage.callTool("scrollPage", {
+			...tab,
+			direction: "down",
+			amount: 400,
+		});
+		expect(result.structuredContent?.ok).toBe(true);
+
+		await expect.poll(() => readScroll(locators.scrollY)).toBeGreaterThan(390);
+		expect(await readScroll(locators.scrollY)).toBeLessThanOrEqual(410);
+	});
+
+	test("scrolls back up toward the top", async ({
+		testAppPage,
+		mcpClientPage,
+	}) => {
+		await testAppPage.navigateToScrollTest();
+		const tab = await mcpClientPage.waitForTabByUrl(
+			testAppPage.page,
+			"scroll-test",
+		);
+
+		const locators = testAppPage.getScrollTestLocators();
+
+		await mcpClientPage.callTool("scrollPage", {
+			...tab,
+			direction: "down",
+			amount: 800,
+		});
+		await expect.poll(() => readScroll(locators.scrollY)).toBeGreaterThan(700);
+
+		const result = await mcpClientPage.callTool("scrollPage", {
+			...tab,
+			direction: "up",
+			amount: 800,
+		});
+		expect(result.structuredContent?.ok).toBe(true);
+
+		await expect.poll(() => readScroll(locators.scrollY)).toBe(0);
+	});
+
+	test("scrolls horizontally right then left", async ({
+		testAppPage,
+		mcpClientPage,
+	}) => {
+		await testAppPage.navigateToScrollTest();
+		const tab = await mcpClientPage.waitForTabByUrl(
+			testAppPage.page,
+			"scroll-test",
+		);
+
+		const locators = testAppPage.getScrollTestLocators();
+		expect(await readScroll(locators.scrollX)).toBe(0);
+
+		const rightResult = await mcpClientPage.callTool("scrollPage", {
+			...tab,
+			direction: "right",
+			amount: 300,
+		});
+		expect(rightResult.structuredContent?.ok).toBe(true);
+		await expect.poll(() => readScroll(locators.scrollX)).toBeGreaterThan(290);
+
+		const leftResult = await mcpClientPage.callTool("scrollPage", {
+			...tab,
+			direction: "left",
+			amount: 300,
+		});
+		expect(leftResult.structuredContent?.ok).toBe(true);
+		await expect.poll(() => readScroll(locators.scrollX)).toBe(0);
+	});
+
+	test("scrolling up at the top is a no-op success", async ({
+		testAppPage,
+		mcpClientPage,
+	}) => {
+		await testAppPage.navigateToScrollTest();
+		const tab = await mcpClientPage.waitForTabByUrl(
+			testAppPage.page,
+			"scroll-test",
+		);
+
+		const locators = testAppPage.getScrollTestLocators();
+		expect(await readScroll(locators.scrollY)).toBe(0);
+
+		const result = await mcpClientPage.callTool("scrollPage", {
+			...tab,
+			direction: "up",
+		});
+		expect(result.structuredContent?.ok).toBe(true);
+		expect(await readScroll(locators.scrollY)).toBe(0);
+	});
+});

--- a/packages/core-extension/src/core/extension-tool-call.ts
+++ b/packages/core-extension/src/core/extension-tool-call.ts
@@ -12,6 +12,7 @@ import type {
 	ExtensionContext,
 	ExtensionToolName,
 	Screenshot,
+	ScrollDirection,
 	Selection,
 } from "../types";
 
@@ -106,6 +107,14 @@ export class ToolCallHandlersUseCase implements ExtensionToolCallInputPort {
 
 	clickOnCoordinates = (tabId: string, x: number, y: number): Promise<void> => {
 		return this.browserDriver.clickOnCoordinates(tabId, x, y);
+	};
+
+	scrollPage = (
+		tabId: string,
+		direction: ScrollDirection,
+		amount?: number,
+	): Promise<void> => {
+		return this.browserDriver.scrollPage(tabId, direction, amount);
 	};
 
 	fillTextToCoordinates = async (

--- a/packages/core-extension/src/output-ports/browser-driver.ts
+++ b/packages/core-extension/src/output-ports/browser-driver.ts
@@ -9,6 +9,7 @@ import type {
 	ExtensionTabInfo,
 	ExtensionWindowInfo,
 	Screenshot,
+	ScrollDirection,
 	Selection,
 	TabContext,
 } from "../types";
@@ -30,6 +31,11 @@ export interface BrowserDriverOutputPort {
 	closeTab(tabId: string): Promise<void>;
 	captureTab(tabId: string): Promise<Screenshot>;
 	getSelection(tabId: string): Promise<Selection>;
+	scrollPage(
+		tabId: string,
+		direction: ScrollDirection,
+		amount?: number,
+	): Promise<void>;
 	clickOnCoordinates(tabId: string, x: number, y: number): Promise<void>;
 	focusOnCoordinates(tabId: string, x: number, y: number): Promise<void>;
 	fillTextToFocusedElement(tabId: string, value: string): Promise<void>;

--- a/packages/core-extension/src/types/extension-tools.ts
+++ b/packages/core-extension/src/types/extension-tools.ts
@@ -8,11 +8,19 @@ import type { Screenshot } from "./screenshot";
 import type { Selection } from "./selection";
 import type { TabContext } from "./tab-context";
 
+/** Direction the viewport is scrolled by the `scrollPage` tool. */
+export type ScrollDirection = "up" | "down" | "left" | "right";
+
 export interface TabSpecificTool {
 	captureTab(tabId: string): Promise<Screenshot>;
 	clickOnCoordinates(tabId: string, x: number, y: number): Promise<void>;
 	clickOnElement(tabId: string, readablePath: string): Promise<void>;
 	closeTab(tabId: string): Promise<void>;
+	scrollPage(
+		tabId: string,
+		direction: ScrollDirection,
+		amount?: number,
+	): Promise<void>;
 	fillTextToCoordinates(
 		tabId: string,
 		x: number,

--- a/packages/core-server/src/core/mcp-descriptions.ts
+++ b/packages/core-server/src/core/mcp-descriptions.ts
@@ -27,7 +27,7 @@ export class McpDescriptionsUseCases implements McpDescriptionsInputPort {
 			"",
 			"Tool selection by manifestVersion:",
 			"- MV2: all tools; prefer element tools; invokeJsFn only as last resort",
-			"- MV3: clickOnElement, fillTextToElement, hitEnterOnElement, openTab, closeTab, getSelection, showHumanHint",
+			"- MV3: clickOnElement, fillTextToElement, hitEnterOnElement, scrollPage, openTab, closeTab, getSelection, showHumanHint",
 			"- MV3 blocked: captureTab, invokeJsFn; avoid coordinate tools (no screenshot source for x/y)",
 			"",
 			"Error recovery:",
@@ -140,6 +140,17 @@ export class McpDescriptionsUseCases implements McpDescriptionsInputPort {
 			"Requires: browserId, windowId, tabId, fnBodyCode.",
 			"Returns: value.result = whatever you return (must be JSON-serializable).",
 			"Avoid: on manifestVersion 3; wrapping in function () { ... }.",
+		].join("\n");
+	};
+
+	scrollPageInstruction = (): string => {
+		return [
+			"Scroll the page viewport in a direction.",
+			"When: target content or elements are off-screen; reveal more of the page before reading or interacting. Works on MV2 and MV3 (no screenshot needed).",
+			"How: direction is up/down/left/right; optional amount in pixels — omit it to scroll ~one viewport (a page). browserId, windowId, tabId from bk:///context.",
+			"Requires: browserId, windowId, tabId, direction.",
+			"Returns: ok=true once scrolled. Already at that edge (nothing to scroll) is still ok=true.",
+			"Avoid: assuming new elements exist — re-read readable-elements after scrolling, snapshots go stale.",
 		].join("\n");
 	};
 

--- a/packages/core-server/src/core/server-tool-calls.ts
+++ b/packages/core-server/src/core/server-tool-calls.ts
@@ -5,6 +5,7 @@ import type {
 	ExtensionWindowInfo,
 	ReadableElementRecord,
 	Screenshot,
+	ScrollDirection,
 	TabSpecificTool,
 } from "@mcp-browser-kit/core-extension";
 import type { MessageChannelRpcClient } from "@mcp-browser-kit/core-utils";
@@ -523,6 +524,36 @@ export class ToolCallUseCases implements ServerToolCallsInputPort {
 			this.logger.info("Clicked on coordinates successfully");
 		} catch (error) {
 			this.logger.error("Failed to click on coordinates", error);
+			throw error;
+		}
+	};
+
+	scrollPage = async (
+		browserId: string,
+		_windowId: string,
+		tabId: string,
+		direction: ScrollDirection,
+		amount?: number,
+	): Promise<void> => {
+		this.logger.info(
+			`Scrolling ${direction}${amount != null ? ` by ${amount}px` : ""} in tab: ${browserId}/${tabId}`,
+		);
+
+		try {
+			const rpcClient = await this.getTabRpc(browserId, tabId);
+			await rpcClient.call({
+				method: "scrollPage" as const,
+				args: [
+					tabId,
+					direction,
+					amount,
+				],
+				extraArgs: {},
+			});
+
+			this.logger.info("Scrolled page successfully");
+		} catch (error) {
+			this.logger.error("Failed to scroll page", error);
 			throw error;
 		}
 	};

--- a/packages/core-server/src/input-ports/mcp-descriptions.ts
+++ b/packages/core-server/src/input-ports/mcp-descriptions.ts
@@ -11,6 +11,7 @@ export interface McpDescriptionsInputPort {
 	fillTextToReadableElementInstruction(): string;
 	hitEnterOnReadableElementInstruction(): string;
 	invokeJsFnInstruction(): string;
+	scrollPageInstruction(): string;
 	closeTabInstruction(): string;
 	getSelectionInstruction(): string;
 	openTabInstruction(): string;

--- a/packages/core-server/src/input-ports/server-tool-calls.ts
+++ b/packages/core-server/src/input-ports/server-tool-calls.ts
@@ -1,6 +1,7 @@
 import type {
 	ExtensionToolName,
 	ReadableElementRecord,
+	ScrollDirection,
 	Selection,
 } from "@mcp-browser-kit/core-extension";
 import type {
@@ -116,6 +117,13 @@ export type ServerToolCallsInputPort = {
 		windowId: string;
 		tabId: string;
 	}>;
+	scrollPage: (
+		browserId: string,
+		windowId: string,
+		tabId: string,
+		direction: ScrollDirection,
+		amount?: number,
+	) => Promise<void>;
 	showHumanHint: (
 		browserId: string,
 		windowId: string,
@@ -176,6 +184,10 @@ export type ServerToolArgsMap = {
 		browserId: string;
 		windowId: string;
 		url: string;
+	};
+	scrollPage: TabRef & {
+		direction: ScrollDirection;
+		amount?: number;
 	};
 	showHumanHint: TabRef & {
 		action: ShowHumanHintParams["action"];

--- a/packages/extension-driven-browser-driver/src/services/driven-browser-driver-base.ts
+++ b/packages/extension-driven-browser-driver/src/services/driven-browser-driver-base.ts
@@ -8,6 +8,7 @@ import type {
 	ExtensionTabInfo,
 	ExtensionWindowInfo,
 	Screenshot,
+	ScrollDirection,
 	Selection,
 	TabContext,
 } from "@mcp-browser-kit/core-extension/types";
@@ -108,6 +109,27 @@ export abstract class DrivenBrowserDriverBase
 		return this.tabRpcService.tabRpcClient.call({
 			method: "dom.getSelection",
 			args: [],
+			extraArgs: {
+				tabId,
+			},
+		});
+	};
+
+	// Scroll Methods
+	scrollPage = (
+		tabId: string,
+		direction: ScrollDirection,
+		amount?: number,
+	): Promise<void> => {
+		this.logger.verbose(
+			`Scrolling ${direction}${amount != null ? ` by ${amount}px` : ""} in tab: ${tabId}`,
+		);
+		return this.tabRpcService.tabRpcClient.call({
+			method: "dom.scrollPage",
+			args: [
+				direction,
+				amount,
+			],
 			extraArgs: {
 				tabId,
 			},

--- a/packages/extension-driven-browser-driver/src/services/tab-dom-tools.ts
+++ b/packages/extension-driven-browser-driver/src/services/tab-dom-tools.ts
@@ -1,4 +1,7 @@
-import type { Selection } from "@mcp-browser-kit/core-extension";
+import type {
+	ScrollDirection,
+	Selection,
+} from "@mcp-browser-kit/core-extension";
 import type { LoggerFactoryOutputPort } from "@mcp-browser-kit/core-extension/output-ports";
 import { LoggerFactoryOutputPort as LoggerFactoryOutputPortSymbol } from "@mcp-browser-kit/core-extension/output-ports";
 import type { Logger } from "@mcp-browser-kit/types";
@@ -54,6 +57,14 @@ export class TabDomTools {
 	) {
 		this.logger = this.loggerFactory.create("TabDomTools");
 	}
+
+	scrollPage = async (direction: ScrollDirection, amount?: number) => {
+		this.logger.info(
+			`Scrolling ${direction}${amount != null ? ` by ${amount}px` : ""}`,
+		);
+		dom.scrollPage(direction, amount ?? undefined);
+		this.logger.verbose("Scroll completed");
+	};
 
 	clickOnCoordinates = async (x: number, y: number) => {
 		this.logger.info(`Clicking on coordinates (${x}, ${y})`);

--- a/packages/extension-driven-browser-driver/src/utils/dom-tools.ts
+++ b/packages/extension-driven-browser-driver/src/utils/dom-tools.ts
@@ -1,3 +1,4 @@
+import type { ScrollDirection } from "@mcp-browser-kit/core-extension/types";
 import delay from "delay";
 import { playClickAnimationOnElement } from "./animation-tools";
 
@@ -61,6 +62,40 @@ export const performAndVerify = async (
 		]);
 	} finally {
 		observer.disconnect();
+	}
+};
+
+/**
+ * Scrolls the viewport one step in `direction`. The step is `amount` pixels
+ * when provided, otherwise ~90% of the viewport along the relevant axis (one
+ * "page"). Uses an instant scroll so the resulting position can be read back
+ * synchronously. Being already clamped at the requested edge is a no-op success;
+ * a failure to move when there is still room throws.
+ */
+export const scrollPage = (direction: ScrollDirection, amount?: number) => {
+	const el = document.scrollingElement ?? document.documentElement;
+	const horizontal = direction === "left" || direction === "right";
+	const step =
+		amount ?? Math.round((horizontal ? innerWidth : innerHeight) * 0.9);
+	const sign = direction === "up" || direction === "left" ? -1 : 1;
+
+	const before = horizontal ? el.scrollLeft : el.scrollTop;
+	window.scrollBy({
+		left: horizontal ? sign * step : 0,
+		top: horizontal ? 0 : sign * step,
+		behavior: "instant",
+	});
+	const after = horizontal ? el.scrollLeft : el.scrollTop;
+
+	if (after === before) {
+		const atEdge =
+			sign < 0
+				? before <= 0
+				: before + (horizontal ? el.clientWidth : el.clientHeight) >=
+					(horizontal ? el.scrollWidth : el.scrollHeight) - 1;
+		if (!atEdge) {
+			throw new Error(`scrollPage(${direction}): no movement`);
+		}
 	}
 };
 

--- a/packages/server-driving-mcp-server/src/services/interaction-tools.ts
+++ b/packages/server-driving-mcp-server/src/services/interaction-tools.ts
@@ -19,6 +19,7 @@ import {
 	coordinateTextInputSchema,
 	readableElementSchema,
 	readableElementTextInputSchema,
+	scrollPageSchema,
 } from "../utils/tool-schemas";
 
 @injectable()
@@ -44,6 +45,74 @@ export class InteractionTools {
 		this.registerClickOnElement(server);
 		this.registerFillTextToElement(server);
 		this.registerHitEnterOnElement(server);
+
+		this.registerScrollPage(server);
+	}
+
+	private registerScrollPage(server: McpServer): void {
+		this.logger.verbose("Registering tool: scrollPage");
+		registerTool(
+			server,
+			"scrollPage",
+			{
+				title: "Scroll the page",
+				description: this.toolDescriptionsInputPort.scrollPageInstruction(),
+				inputSchema: scrollPageSchema,
+				outputSchema: actionOutputSchema,
+				annotations: {
+					readOnlyHint: false,
+					destructiveHint: false,
+					idempotentHint: false,
+					openWorldHint: true,
+				},
+			},
+			async ({ browserId, windowId, tabId, direction, amount }) => {
+				this.logger.info("Executing scrollPage", {
+					browserId,
+					tabId,
+					direction,
+					amount,
+				});
+				const overScroll = await over(() =>
+					this.toolsInputPort.scrollPage(
+						browserId,
+						windowId,
+						tabId,
+						direction,
+						amount,
+					),
+				);
+
+				if (!overScroll.ok) {
+					this.logger.error("Failed to scroll page", {
+						browserId,
+						tabId,
+						direction,
+						amount,
+						reason: overScroll.reason,
+					});
+					return createOverResponse(actionOutputSchema, {
+						ok: false,
+						reason: String(overScroll.reason),
+					});
+				}
+
+				this.logger.verbose("Scrolled page", {
+					browserId,
+					tabId,
+					direction,
+					amount,
+				});
+				return createOverResponse(
+					actionOutputSchema,
+					{
+						ok: true,
+						value: {},
+					},
+					"Done",
+				);
+			},
+		);
 	}
 
 	private registerClickOnCoordinates(server: McpServer): void {

--- a/packages/server-driving-mcp-server/src/utils/tool-schemas.ts
+++ b/packages/server-driving-mcp-server/src/utils/tool-schemas.ts
@@ -90,6 +90,24 @@ export const openTabSchema = {
 		.describe("URL to open, including scheme (e.g. https://example.com)"),
 };
 
+export const scrollPageSchema = {
+	...tabRefSchema,
+	direction: z
+		.enum([
+			"up",
+			"down",
+			"left",
+			"right",
+		])
+		.describe("Direction to scroll the viewport"),
+	amount: z
+		.number()
+		.int()
+		.positive()
+		.optional()
+		.describe("Pixels to scroll; defaults to ~one viewport when omitted"),
+};
+
 export const showHumanHintInputSchema = {
 	...tabRefSchema,
 	action: z
@@ -236,6 +254,7 @@ type ServerToolOverSchemaMap = {
 	clickOnElement: typeof actionOutputSchema;
 	fillTextToElement: typeof actionOutputSchema;
 	hitEnterOnElement: typeof actionOutputSchema;
+	scrollPage: typeof actionOutputSchema;
 	showHumanHint: typeof showHumanHintOutputSchema;
 };
 


### PR DESCRIPTION
Add a scrollPage browser tool that scrolls the active tab's viewport in a direction (up/down/left/right) by an optional pixel amount, defaulting to ~one viewport. Works on both MV2 and MV3 since it needs no screenshot.

Threads through the existing hexagonal layers like the other interaction tools: ExtensionTools/BrowserDriverOutputPort ports, the extension and server tool-call use cases, the tab DOM adapter (instant scrollBy with a synchronous move check; already-at-edge counts as success), and the MCP server schema, registration, and description. Adds a scroll-test e2e fixture page and scroll-tools.spec.ts.