### PR TITLE
fix: serialize per-tab tool calls to prevent concurrency races

### DIFF
--- a/apps/ext-e2e/src/tests/concurrent-tool-calls.spec.ts
+++ b/apps/ext-e2e/src/tests/concurrent-tool-calls.spec.ts
@@ -1,0 +1,197 @@
+import { expect, test } from "../fixtures/ext-test";
+import { TestAppPage } from "../pages/test-app-page";
+import { expectToBeDefined } from "../test-utils/assert-defined";
+
+/**
+ * Exercises an agent firing multiple *separate* tools/call requests against
+ * the same tab concurrently (via Promise.all, without awaiting one before
+ * starting the next) — not a batched/composite call. The MCP layer dispatches
+ * these concurrently by design (different tabs/browsers must stay parallel),
+ * but the content-script side that touches a given tab's DOM must serialize
+ * them so they don't interleave against shared per-tab state.
+ */
+test.describe("Concurrent tool calls", () => {
+	test.beforeEach(async ({ mcpClientPage }) => {
+		test.setTimeout(45000);
+		await mcpClientPage.startServer();
+		await mcpClientPage.connect();
+		await mcpClientPage.waitForBrowsers();
+	});
+
+	test("serializes concurrent calls against the same tab in arrival order", async ({
+		testAppPage,
+		mcpClientPage,
+	}) => {
+		await testAppPage.navigateToFormTest();
+
+		const tab = await mcpClientPage.waitForTabByUrl(
+			testAppPage.page,
+			"form-test",
+		);
+		const tabUri = await mcpClientPage.waitForTabUriByUrl(
+			testAppPage.page,
+			"form-test",
+		);
+		const elements = await mcpClientPage.readAllSnapshotElements(tabUri);
+		const usernameInputPath = elements.find(
+			(el) => el[1] === "input" && el[2]?.includes("Enter username"),
+		)?.[0];
+		const emailInputPath = elements.find(
+			(el) => el[1] === "input" && el[2]?.includes("Enter email"),
+		)?.[0];
+		expectToBeDefined(usernameInputPath);
+		expectToBeDefined(emailInputPath);
+
+		// A long value takes noticeably longer to type than a short one, so
+		// their relative completion order reveals whether the two calls were
+		// serialized (short queued behind long → finishes later) or ran
+		// truly concurrently (short finishes first, on its own timer).
+		const longValue = "a".repeat(40);
+		const shortValue = "b";
+
+		const startedAt = Date.now();
+		let longDoneAt = -1;
+		let shortDoneAt = -1;
+
+		const longCall = mcpClientPage
+			.callTool("fillTextToElement", {
+				...tab,
+				readablePath: usernameInputPath,
+				value: longValue,
+			})
+			.then((result) => {
+				longDoneAt = Date.now() - startedAt;
+				return result;
+			});
+		const shortCall = mcpClientPage
+			.callTool("fillTextToElement", {
+				...tab,
+				readablePath: emailInputPath,
+				value: shortValue,
+			})
+			.then((result) => {
+				shortDoneAt = Date.now() - startedAt;
+				return result;
+			});
+
+		const [longResult, shortResult] = await Promise.all([
+			longCall,
+			shortCall,
+		]);
+
+		expect(longResult.structuredContent?.ok).toBe(true);
+		expect(shortResult.structuredContent?.ok).toBe(true);
+		// Only true if the short call's content-script execution was queued
+		// behind the long one; without serialization the shorter task runs in
+		// parallel and finishes first.
+		expect(shortDoneAt).toBeGreaterThanOrEqual(longDoneAt);
+	});
+
+	test("both fields end up with the correct value after concurrent fills", async ({
+		testAppPage,
+		mcpClientPage,
+	}) => {
+		await testAppPage.navigateToFormTest();
+
+		const tab = await mcpClientPage.waitForTabByUrl(
+			testAppPage.page,
+			"form-test",
+		);
+		const tabUri = await mcpClientPage.waitForTabUriByUrl(
+			testAppPage.page,
+			"form-test",
+		);
+		const elements = await mcpClientPage.readAllSnapshotElements(tabUri);
+		const usernameInputPath = elements.find(
+			(el) => el[1] === "input" && el[2]?.includes("Enter username"),
+		)?.[0];
+		const emailInputPath = elements.find(
+			(el) => el[1] === "input" && el[2]?.includes("Enter email"),
+		)?.[0];
+		expectToBeDefined(usernameInputPath);
+		expectToBeDefined(emailInputPath);
+
+		await Promise.all([
+			mcpClientPage.callTool("fillTextToElement", {
+				...tab,
+				readablePath: usernameInputPath,
+				value: "concurrentuser",
+			}),
+			mcpClientPage.callTool("fillTextToElement", {
+				...tab,
+				readablePath: emailInputPath,
+				value: "concurrent@example.com",
+			}),
+		]);
+
+		const locators = testAppPage.getFormTestLocators();
+		await expect(locators.usernameInput).toHaveValue("concurrentuser");
+		await expect(locators.emailInput).toHaveValue("concurrent@example.com");
+	});
+
+	test("concurrent calls on different tabs are not serialized against each other", async ({
+		context,
+		testAppPage,
+		mcpClientPage,
+	}) => {
+		await testAppPage.navigateToFormTest();
+
+		const tab1 = await mcpClientPage.waitForTabByUrl(
+			testAppPage.page,
+			"form-test",
+		);
+		const tabUri1 = await mcpClientPage.waitForTabUriByUrl(
+			testAppPage.page,
+			"form-test",
+		);
+
+		const windowRef = await mcpClientPage.getFirstWindowRef();
+		const newPagePromise = context.waitForEvent("page");
+		const openResult = await mcpClientPage.callTool("openTab", {
+			...windowRef,
+			url: testAppPage.formTestUrl,
+		});
+		const newPage = await newPagePromise;
+		await newPage.waitForLoadState("networkidle");
+		const tab2 = openResult.structuredContent?.value;
+		expectToBeDefined(tab2);
+		const tabUri2 = await mcpClientPage.waitForTabUriByUrl(
+			newPage,
+			"form-test",
+		);
+		const testAppPage2 = new TestAppPage(newPage);
+
+		const elements1 = await mcpClientPage.readAllSnapshotElements(tabUri1);
+		const usernamePath1 = elements1.find(
+			(el) => el[1] === "input" && el[2]?.includes("Enter username"),
+		)?.[0];
+		const elements2 = await mcpClientPage.readAllSnapshotElements(tabUri2);
+		const usernamePath2 = elements2.find(
+			(el) => el[1] === "input" && el[2]?.includes("Enter username"),
+		)?.[0];
+		expectToBeDefined(usernamePath1);
+		expectToBeDefined(usernamePath2);
+
+		const [result1, result2] = await Promise.all([
+			mcpClientPage.callTool("fillTextToElement", {
+				...tab1,
+				readablePath: usernamePath1,
+				value: "tab1user",
+			}),
+			mcpClientPage.callTool("fillTextToElement", {
+				...tab2,
+				readablePath: usernamePath2,
+				value: "tab2user",
+			}),
+		]);
+
+		expect(result1.structuredContent?.ok).toBe(true);
+		expect(result2.structuredContent?.ok).toBe(true);
+		await expect(testAppPage.getFormTestLocators().usernameInput).toHaveValue(
+			"tab1user",
+		);
+		await expect(testAppPage2.getFormTestLocators().usernameInput).toHaveValue(
+			"tab2user",
+		);
+	});
+});

--- a/packages/core-utils/src/message-channel-rpc/server.ts
+++ b/packages/core-utils/src/message-channel-rpc/server.ts
@@ -6,15 +6,36 @@ import type {
 	ResolveMessage,
 } from "./types/message-channel-rpc";
 
+/**
+ * Controls how concurrently-arriving `defer` messages are dispatched:
+ * - "queue": run one at a time, in arrival order (safe against shared
+ *   mutable state, e.g. tab context, DOM mutation observers, overlays).
+ * - "parallel": run each message as soon as it arrives, with no ordering
+ *   guarantees between them.
+ */
+export type RpcDispatchMode = "queue" | "parallel";
+
 export class MessageChannelRpcServer<
 	T extends {},
 	U extends ExtractProcedures<T> = ExtractProcedures<T>,
 > {
 	private procedures: U;
 	private unsubscribe?: () => void;
+	private readonly dispatchMode: RpcDispatchMode;
+	// Serializes handleDefer calls per instance when dispatchMode is "queue",
+	// so concurrently-arriving messages run one at a time instead of
+	// interleaving. handleDefer always resolves (never rejects), so this
+	// chain can't get stuck.
+	private queue: Promise<unknown> = Promise.resolve();
 
-	constructor(procedures: U) {
+	constructor(
+		procedures: U,
+		options?: {
+			dispatchMode?: RpcDispatchMode;
+		},
+	) {
 		this.procedures = procedures;
+		this.dispatchMode = options?.dispatchMode ?? "parallel";
 	}
 
 	startListen = (channel: MessageChannelRpcServerType) => {
@@ -22,9 +43,16 @@ export class MessageChannelRpcServer<
 		this.stopListen();
 
 		this.unsubscribe = channel.incoming.on("defer", (message: DeferMessage) => {
-			this.handleDefer(message).then((result) => {
-				channel.outgoing.emit("resolve", result);
-			});
+			const run = () =>
+				this.handleDefer(message).then((result) => {
+					channel.outgoing.emit("resolve", result);
+				});
+
+			if (this.dispatchMode === "queue") {
+				this.queue = this.queue.then(run);
+			} else {
+				run();
+			}
 		});
 
 		return this.unsubscribe;

--- a/packages/extension-driven-browser-driver/src/services/tab-tools-setup.ts
+++ b/packages/extension-driven-browser-driver/src/services/tab-tools-setup.ts
@@ -87,8 +87,12 @@ export class TabToolsSetup {
 		this.channel = new EmitteryMessageChannel<DeferData, ResolveData>();
 		this.logger.verbose("Created EmitteryMessageChannel");
 
-		// Initialize the RPC server with tab tools
-		this.rpcServer = new MessageChannelRpcServer(this.tabTools);
+		// Initialize the RPC server with tab tools. Queued dispatch serializes
+		// concurrent tool calls against this tab's shared mutable state (tab
+		// context, DOM mutation observers, human-hint overlay).
+		this.rpcServer = new MessageChannelRpcServer(this.tabTools, {
+			dispatchMode: "queue",
+		});
 		this.logger.verbose("Created MessageChannelRpcServer with tab tools");
 
 		// Connect the server to the EmitteryMessageChannel

--- a/packages/extension-driving-trpc-controller/src/services/extension-driving-trpc-controller.ts
+++ b/packages/extension-driving-trpc-controller/src/services/extension-driving-trpc-controller.ts
@@ -92,7 +92,12 @@ export class ExtensionDrivingTrpcController {
 			// Get or create a persistent RPC server for this channel
 			let rpcServer = this.rpcServers.get(channel.channelId);
 			if (!rpcServer) {
-				rpcServer = new MessageChannelRpcServer(this._toolCallHandlers);
+				// Parallel dispatch: requests to different tabs/targets shouldn't be
+				// serialized behind one another at this hop. Per-tab serialization
+				// is enforced downstream by the tab's own RPC server.
+				rpcServer = new MessageChannelRpcServer(this._toolCallHandlers, {
+					dispatchMode: "parallel",
+				});
 				this.rpcServers.set(channel.channelId, rpcServer);
 				this.logger.info("New persistent MessageChannelRpcServer created", {
 					channelId: channel.channelId,

--- a/packages/server-driven-trpc-channel-provider/src/routers/defer.ts
+++ b/packages/server-driven-trpc-channel-provider/src/routers/defer.ts
@@ -38,26 +38,42 @@ async function* deferSubscription(
 	const channel = extensionChannelProvider.openChannel(channelId);
 	logger.verbose(`Channel opened: ${channelId}`);
 
-	let defer = Promise.withResolvers<DeferMessage>();
+	// Buffers defer messages in a FIFO queue rather than a single promise slot,
+	// so concurrently-arriving messages (e.g. two tools/call requests
+	// dispatched in parallel) are all forwarded in arrival order instead of
+	// silently dropping any message that arrives before the previous one is
+	// consumed by the loop below.
+	const pendingMessages: DeferMessage[] = [];
+	let notifyArrival = Promise.withResolvers<void>();
 
 	const unsubscribe = channel.outgoing.on("defer", (message: DeferMessage) => {
 		logger.verbose(`Received defer message on channel ${channelId}:`, message);
-		defer.resolve(message);
-		defer = Promise.withResolvers<DeferMessage>();
+		pendingMessages.push(message);
+		notifyArrival.resolve();
 	});
 
 	let stopped = false;
+	let abortError: Error | undefined;
 	if (signal) {
 		signal.onabort = () => {
 			logger.info(`Subscription aborted for channel: ${channelId}`);
 			stopped = true;
+			abortError = new Error("Client closed subscription");
 			unsubscribe();
-			defer.reject(new Error("Client closed subscription"));
+			notifyArrival.resolve();
 			extensionChannelProvider.closeChannel(channelId);
 		};
 	}
 	while (!stopped) {
-		yield await defer.promise;
+		if (pendingMessages.length === 0) {
+			await notifyArrival.promise;
+			notifyArrival = Promise.withResolvers<void>();
+			continue;
+		}
+		yield pendingMessages.shift() as DeferMessage;
+	}
+	if (abortError) {
+		throw abortError;
 	}
 	logger.info(`Subscription ended for channel: ${channelId}`);
 }


### PR DESCRIPTION
## What
Fixes real concurrency races that occur when an agent fires multiple separate `tools/call` requests at once, rather than adding a new composite/batch tool.

## Changes
- **`packages/core-utils/src/message-channel-rpc/server.ts`** — `MessageChannelRpcServer` now supports a configurable `dispatchMode`: `"queue"` (serialize handleDefer calls in arrival order) or `"parallel"` (dispatch immediately, default).
- **`packages/extension-driven-browser-driver/src/services/tab-tools-setup.ts`** — the extension background → tab content-script hop uses `dispatchMode: "queue"`, since this is where shared per-tab mutable state lives (tab context, DOM mutation observers, human-hint overlay).
- **`packages/extension-driving-trpc-controller/src/services/extension-driving-trpc-controller.ts`** — the MCP server → extension background hop uses `dispatchMode: "parallel"`, so requests to different tabs/browsers aren't needlessly serialized against each other.
- **`packages/server-driven-trpc-channel-provider/src/routers/defer.ts`** — fixes a real message-drop bug found while testing: the WS `defer` subscription used a single promise slot to relay events, so two `defer" messages arriving before the subscription loop caught up would silently drop the older one (causing the corresponding tool call to hang forever). Replaced with a FIFO queue so every message is forwarded in arrival order.
- **`apps/ext-e2e/src/tests/concurrent-tool-calls.spec.ts`** — new e2e spec covering:
  - Same-tab concurrent calls are serialized in arrival order (timing-based assertion)
  - Both fields end up correct after concurrent fills to the same tab
  - Different-tab concurrent calls are NOT serialized against each other
