### PR TITLE
feat: add support for Firefox channel resolution in signing and release processes

### DIFF
--- a/etc/scripts/moon-tasks/extension-sign-firefox.ts
+++ b/etc/scripts/moon-tasks/extension-sign-firefox.ts
@@ -3,7 +3,7 @@ import "zx/globals";
 import { workDirs } from "@mcp-browser-kit/scripts/utils/work-dirs";
 import fse from "fs-extra";
 import * as R from "ramda";
-import { getProjectRoot } from "../utils/get-envs";
+import { getFirefoxChannel, getProjectRoot } from "../utils/get-envs";
 import { getExtensionName } from "../utils/get-extension-name";
 
 $.verbose = true;
@@ -19,6 +19,9 @@ const signArtifactTmpDir = path.resolve(
 const distDir = path.resolve(projectRoot, "target/extension/dist");
 const extensionName = await getExtensionName(projectRoot);
 
+const channel = getFirefoxChannel();
+console.log(`Signing for Firefox channel "${channel}"`);
+
 const command = [
 	"web-ext",
 	"sign",
@@ -31,7 +34,7 @@ const command = [
 	"--api-secret",
 	"$FIREFOX_API_SECRET",
 	"--channel",
-	"unlisted",
+	channel,
 ].join(" ");
 
 await $({

--- a/etc/scripts/moon-tasks/versions-patch.ts
+++ b/etc/scripts/moon-tasks/versions-patch.ts
@@ -3,38 +3,15 @@ import "zx/globals";
 import { workDirs } from "@mcp-browser-kit/scripts/utils/work-dirs";
 import fse from "fs-extra";
 import semver from "semver";
-import simpleGit from "simple-git";
-import { getReleaseTag } from "../utils/get-envs";
+import { resolveReleaseTag, V0_TAG_PATTERN } from "../utils/release-tag";
 
-let rawTag = getReleaseTag();
-
-if (rawTag) {
-	console.log(`Using RELEASE_TAG from environment: "${rawTag}"`);
-} else {
-	console.log("RELEASE_TAG not set, falling back to git tag lookup...");
-	const git = simpleGit(workDirs.path);
-	const tagOutput = await git.raw([
-		"tag",
-		"--points-at",
-		"HEAD",
-		"--sort=-creatordate",
-	]);
-	const tags = tagOutput.trim().split("\n").filter(Boolean);
-
-	if (tags.length === 0) {
-		console.error("No git tag found on HEAD.");
-		process.exit(1);
-	}
-
-	rawTag = tags[0];
-	console.log(`Found git tag "${rawTag}"`);
-}
+const rawTag = await resolveReleaseTag();
 
 // V0 tags use the format v0.yyMMd.dhhmm-ss (e.g., v0.26032.00830-05).
 // These contain leading zeros which makes them invalid semver, so we parse them manually.
 // Release tags use standard semver (e.g., v1.2.3).
 
-const v0Match = rawTag.match(/^v(0\.\d{5}\.\d{5})-(\d{2})$/);
+const v0Match = rawTag.match(V0_TAG_PATTERN);
 
 // Replace leading zeros with 9 to produce valid version segments
 // that preserve the original string length (e.g., "00830" → "99830", "05" → "95").

--- a/etc/scripts/utils/get-envs.ts
+++ b/etc/scripts/utils/get-envs.ts
@@ -5,6 +5,7 @@ enum EnvVars {
 	WorkspaceRoot = "WORKSPACE_ROOT",
 	FirefoxApiKey = "FIREFOX_API_KEY",
 	FirefoxApiSecret = "FIREFOX_API_SECRET",
+	FirefoxChannel = "FIREFOX_CHANNEL",
 	YarnNpmAuthToken = "YARN_NPM_AUTH_TOKEN",
 	ReleaseTag = "RELEASE_TAG",
 }
@@ -23,6 +24,18 @@ export const getWorkspaceRoot = () => getEnv(EnvVars.WorkspaceRoot);
 export const getFirefoxApiKey = () => getEnv(EnvVars.FirefoxApiKey);
 
 export const getFirefoxApiSecret = () => getEnv(EnvVars.FirefoxApiSecret);
+
+export const getFirefoxChannel = (): "listed" | "unlisted" => {
+	const env = cleanEnv(process.env, {
+		[EnvVars.FirefoxChannel]: str({
+			choices: [
+				"listed",
+				"unlisted",
+			],
+		}),
+	});
+	return env[EnvVars.FirefoxChannel];
+};
 
 export const getYarnNpmAuthToken = () => getEnv(EnvVars.YarnNpmAuthToken);
 

--- a/etc/scripts/utils/release-tag.ts
+++ b/etc/scripts/utils/release-tag.ts
@@ -1,0 +1,39 @@
+import { workDirs } from "@mcp-browser-kit/scripts/utils/work-dirs";
+import simpleGit from "simple-git";
+import { getReleaseTag } from "./get-envs";
+
+// V0 tags use the format v0.yyMMd.dhhmm-ss (e.g., v0.26032.00830-05).
+// These contain leading zeros which makes them invalid semver, so we match them manually.
+// Release tags use standard semver (e.g., v1.2.3).
+export const V0_TAG_PATTERN = /^v(0\.\d{5}\.\d{5})-(\d{2})$/;
+
+export const resolveFirefoxChannel = (tag: string): "listed" | "unlisted" =>
+	V0_TAG_PATTERN.test(tag) ? "unlisted" : "listed";
+
+export const resolveReleaseTag = async (): Promise<string> => {
+	const rawTag = getReleaseTag();
+
+	if (rawTag) {
+		console.log(`Using RELEASE_TAG from environment: "${rawTag}"`);
+		return rawTag;
+	}
+
+	console.log("RELEASE_TAG not set, falling back to git tag lookup...");
+	const git = simpleGit(workDirs.path);
+	const tagOutput = await git.raw([
+		"tag",
+		"--points-at",
+		"HEAD",
+		"--sort=-creatordate",
+	]);
+	const tags = tagOutput.trim().split("\n").filter(Boolean);
+
+	if (tags.length === 0) {
+		console.error("No git tag found on HEAD.");
+		process.exit(1);
+	}
+
+	const tag = tags[0];
+	console.log(`Found git tag "${tag}"`);
+	return tag;
+};

--- a/etc/scripts/workflows/release-publish.ts
+++ b/etc/scripts/workflows/release-publish.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env -S yarn dlx tsx
 import "zx/globals";
 import fse from "fs-extra";
+import { resolveFirefoxChannel, resolveReleaseTag } from "../utils/release-tag";
 import { workDirs } from "../utils/work-dirs";
 
 $.verbose = true;
@@ -8,6 +9,12 @@ $.verbose = true;
 await fse.emptyDir(workDirs.target.release.path);
 
 cd(workDirs.etc.workflowRuntime.path);
+
+const releaseTag = await resolveReleaseTag();
+const firefoxChannel = resolveFirefoxChannel(releaseTag);
+console.log(
+	`Resolved release tag "${releaseTag}" to Firefox channel "${firefoxChannel}"`,
+);
 
 const hasNpmToken = Boolean(process.env.YARN_NPM_AUTH_TOKEN);
 
@@ -80,6 +87,11 @@ await $`${[
 				process.env.RELEASE_TAG,
 			]
 		: []),
+	"with-env-variable",
+	"--name",
+	"FIREFOX_CHANNEL",
+	"--value",
+	firefoxChannel,
 	"with-moon-task",
 	"--task",
 	"scripts:versions-patch",


### PR DESCRIPTION
## Summary
- Resolve the Firefox Add-ons publishing channel (`listed` vs `unlisted`) from the release tag in `release-publish.ts`, and forward it to the Dagger container as `FIREFOX_CHANNEL`
- `extension-sign-firefox.ts` now reads the channel from `FIREFOX_CHANNEL` via a new `getFirefoxChannel()` env helper instead of hardcoding `unlisted`
- Extract shared tag resolution/pattern logic (`resolveReleaseTag`, `V0_TAG_PATTERN`, `resolveFirefoxChannel`) into `etc/scripts/utils/release-tag.ts`, and reuse it in `versions-patch.ts` to remove duplicated tag-parsing code

## Test plan
- [ ] `moon run scripts:biome-check`
- [ ] `tsc --noEmit` on changed scripts
- [ ] Trigger a dev release (`v0.*` tag) and confirm Firefox signing uses `unlisted` channel
- [ ] Trigger a production release (semver tag) and confirm Firefox signing uses `listed` channel

Made with [Cursor](https://cursor.com)