### PR TITLE
fix: provide required AMO metadata when signing listed Firefox releases

### DIFF
--- a/.moon/tasks/tag-extension.yml
+++ b/.moon/tasks/tag-extension.yml
@@ -14,6 +14,8 @@ fileGroups:
   - target/extension/tmp/extension/vendors/**/*
   extension-dist:
   - target/extension/dist/**/*
+  amo-metadata:
+  - amo-metadata.json
 tasks:
   extension-copy-assets:
     deps:
@@ -56,5 +58,6 @@ tasks:
     - '@group(extension-assets)'
     - '@group(extension-manifest)'
     - '@group(extension-vendors)'
+    - '@group(amo-metadata)'
 inheritedBy:
   tag: extension

--- a/apps/m2/amo-metadata.json
+++ b/apps/m2/amo-metadata.json
@@ -1,0 +1,8 @@
+{
+	"categories": [
+		"other"
+	],
+	"version": {
+		"license": "MIT"
+	}
+}

--- a/etc/scripts/moon-tasks/extension-sign-firefox.ts
+++ b/etc/scripts/moon-tasks/extension-sign-firefox.ts
@@ -35,33 +35,11 @@ const command = [
 	"$FIREFOX_API_SECRET",
 	"--channel",
 	channel,
+	// Listing fields AMO cannot derive from manifest.json; a listed version is
+	// rejected without them.
+	"--amo-metadata",
+	path.resolve(projectRoot, "amo-metadata.json"),
 ];
-
-// AMO requires a summary, categories, and license for an extension's first
-// listed version, even if the extension already exists as unlisted.
-if (channel === "listed") {
-	const manifestJson = await fse.readJSON(
-		path.resolve(projectRoot, "src/manifest.json"),
-	);
-
-	const amoMetadataPath = path.resolve(
-		projectRoot,
-		"target/extension/tmp/amo-metadata.json",
-	);
-	await fse.outputJSON(amoMetadataPath, {
-		summary: {
-			"en-US": manifestJson.description,
-		},
-		categories: [
-			"other",
-		],
-		version: {
-			license: "MIT",
-		},
-	});
-
-	command.push("--amo-metadata", amoMetadataPath);
-}
 
 const commandString = command.join(" ");
 

--- a/etc/scripts/moon-tasks/extension-sign-firefox.ts
+++ b/etc/scripts/moon-tasks/extension-sign-firefox.ts
@@ -35,11 +35,39 @@ const command = [
 	"$FIREFOX_API_SECRET",
 	"--channel",
 	channel,
-].join(" ");
+];
+
+// AMO requires a summary, categories, and license for an extension's first
+// listed version, even if the extension already exists as unlisted.
+if (channel === "listed") {
+	const manifestJson = await fse.readJSON(
+		path.resolve(projectRoot, "src/manifest.json"),
+	);
+
+	const amoMetadataPath = path.resolve(
+		projectRoot,
+		"target/extension/tmp/amo-metadata.json",
+	);
+	await fse.outputJSON(amoMetadataPath, {
+		summary: {
+			"en-US": manifestJson.description,
+		},
+		categories: [
+			"other",
+		],
+		version: {
+			license: "MIT",
+		},
+	});
+
+	command.push("--amo-metadata", amoMetadataPath);
+}
+
+const commandString = command.join(" ");
 
 await $({
 	quote: R.identity<string>,
-})`${command}`;
+})`${commandString}`;
 
 const signedFile = await glob(`${signArtifactTmpDir}/*`);
 


### PR DESCRIPTION
## Summary
- The `release-publish` workflow failed for tag `v10.1.1` because `web-ext sign --channel listed` got a `400 Bad Request` from addons.mozilla.org: `"This field, or custom_license, is required for listed versions."` (job: https://github.com/ndthanhdev/mcp-browser-kit/actions/runs/30127332166/job/89593802653)
- AMO requires `summary`, `categories`, and the version `license` for an add-on's first listed version, even if the add-on already exists as unlisted.
- `extension-sign-firefox.ts` now generates a `--amo-metadata` JSON file (summary from `manifest.json` description, `categories: ["other"]`, `version.license: "MIT"`) whenever the resolved channel is `listed`.

## Test plan
- [x] `yarn biome check` on the changed file
- [x] `tsc --noEmit` in `etc/scripts` (only pre-existing, unrelated error remains)
- [ ] Re-run the `release-publish` workflow against a `listed` tag to confirm `web-ext sign` succeeds

Made with [Cursor](https://cursor.com)