### PR TITLE
docs: add Firefox Add-on badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # MCP Browser Kit
 
 [![NPM Version](https://img.shields.io/npm/v/%40mcp-browser-kit%2Fserver)](https://www.npmjs.com/package/@mcp-browser-kit/server)
+[![Firefox Add-on](https://img.shields.io/amo/v/mcp-browserkit-m2?logo=firefoxbrowser&logoColor=white&label=Firefox%20Add-on)](https://addons.mozilla.org/en-US/firefox/addon/mcp-browserkit-m2/)
 [![Workspace Updated](https://github.com/ndthanhdev/mcp-browser-kit/actions/workflows/workspace-updated.yml/badge.svg)](https://github.com/ndthanhdev/mcp-browser-kit/actions/workflows/workspace-updated.yml)
 [![Checked with Biome](https://img.shields.io/badge/Checked_with-Biome-60a5fa?style=flat&logo=biome)](https://biomejs.dev)
 [![Trust Score](https://archestra.ai/mcp-catalog/api/badge/quality/ndthanhdev/mcp-browser-kit)](https://archestra.ai/mcp-catalog/ndthanhdev__mcp-browser-kit)


### PR DESCRIPTION
Adds a shields.io AMO badge for the Firefox extension next to the existing NPM version badge.

```md
[![Firefox Add-on](https://img.shields.io/amo/v/mcp-browserkit-m2?logo=firefoxbrowser&logoColor=white&label=Firefox%20Add-on)](https://addons.mozilla.org/en-US/firefox/addon/mcp-browserkit-m2/)
```

- Uses the `firefoxbrowser` logo plus a `Firefox Add-on` label (icon + text).
- Links to https://addons.mozilla.org/en-US/firefox/addon/mcp-browserkit-m2/
- Badge endpoint verified live, currently resolves to `v10.1.3`.

README-only change; no build or runtime impact.