### PR TITLE
feat: skip ext-wxt -next artifacts on prod releases

### DIFF
--- a/.moon/tasks/tag-wxt.yml
+++ b/.moon/tasks/tag-wxt.yml
@@ -2,7 +2,6 @@ $schema: https://moonrepo.dev/schemas/tasks.json
 fileGroups:
   wxt-config:
   - wxt.config.ts
-  - web-ext.config.ts
   wxt-sources:
   - src/**/*
   - entrypoints/**/*
@@ -16,17 +15,6 @@ fileGroups:
   wxt-extension-dist:
   - target/extension/dist/**/*
 tasks:
-  wxt-install-browser:
-    toolchain: node
-    preset: utility
-    deps:
-    - scripts:browser-install
-    env:
-      PLAYWRIGHT_BROWSERS_PATH: $workspaceRoot/.tmp/browsers
-    script: |
-      CHROME="$(node -e "console.log(require('@playwright/test').chromium.executablePath())")"
-      FIREFOX="$(node -e "console.log(require('@playwright/test').firefox.executablePath())")"
-      printf 'import { defineWebExtConfig } from "wxt";\n\nexport default defineWebExtConfig({\n\tbinaries: {\n\t\tchrome: "%s",\n\t\tfirefox: "%s",\n\t},\n});\n' "$CHROME" "$FIREFOX" > web-ext.config.ts
   wxt-prepare:
     toolchain: node
     script: wxt prepare
@@ -39,7 +27,9 @@ tasks:
     toolchain: node
     preset: server
     deps:
-    - wxt-install-browser
+    - scripts:browser-install
+    env:
+      PLAYWRIGHT_BROWSERS_PATH: $workspaceRoot/.tmp/browsers
     script: wxt
     inputs:
     - '@group(wxt-config)'
@@ -76,7 +66,14 @@ tasks:
     toolchain: node
     preset: server
     deps:
-    - wxt-install-browser
+    - scripts:browser-install
+    env:
+      PLAYWRIGHT_BROWSERS_PATH: $workspaceRoot/.tmp/browsers
+      # Playwright's Firefox build has no Wayland support — on a Wayland
+      # session it aborts inside wl_display_read_events before binding the
+      # debugger port, which surfaces as web-ext failing with ECONNREFUSED.
+      # Force XWayland.
+      MOZ_ENABLE_WAYLAND: "0"
     script: wxt -b firefox
     inputs:
     - '@group(wxt-config)'

--- a/apps/ext-wxt/.gitignore
+++ b/apps/ext-wxt/.gitignore
@@ -12,7 +12,6 @@ node_modules
 stats.html
 stats-*.json
 .wxt
-web-ext.config.ts
 
 # Editor directories and files
 .vscode/*

--- a/apps/ext-wxt/moon.yml
+++ b/apps/ext-wxt/moon.yml
@@ -11,6 +11,6 @@ tags:
 tasks:
   build:
     deps:
-    - ~:wxt-collect-chrome
+    - ~:wxt-zip
 toolchains:
   default: node

--- a/apps/ext-wxt/package.json
+++ b/apps/ext-wxt/package.json
@@ -18,6 +18,7 @@
 		"react-dom": "^19.2.7"
 	},
 	"devDependencies": {
+		"@playwright/test": "^1.58.2",
 		"@types/react": "^19.2.14",
 		"@types/react-dom": "^19.2.3",
 		"@wxt-dev/auto-icons": "^1.1.1",

--- a/apps/ext-wxt/wxt.config.ts
+++ b/apps/ext-wxt/wxt.config.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { chromium, firefox } from "@playwright/test";
 import { defineConfig } from "wxt";
 
 // Patched by scripts:versions-patch at release time. Kept out of package.json
@@ -10,8 +11,27 @@ const { version } = JSON.parse(
 	version: string;
 };
 
+// Browser binaries for `wxt dev`, resolved from the Playwright-pinned builds
+// that scripts:browser-install places in PLAYWRIGHT_BROWSERS_PATH
+// (.tmp/browsers). executablePath() only computes a path — it doesn't check the
+// file exists — and WXT loads this config for `build`/`zip` too, which never
+// launch a browser. Omit anything absent so web-ext falls back to its own
+// browser discovery.
+const resolveBinaries = (): Record<string, string> => {
+	const candidates: Record<string, string> = {
+		chrome: chromium.executablePath(),
+		firefox: firefox.executablePath(),
+	};
+	return Object.fromEntries(
+		Object.entries(candidates).filter(([, binary]) => fs.existsSync(binary)),
+	);
+};
+
 // See https://wxt.dev/api/config.html
 export default defineConfig({
+	webExt: {
+		binaries: resolveBinaries(),
+	},
 	modules: [
 		"@wxt-dev/module-react",
 		"@wxt-dev/auto-icons",

--- a/etc/scripts/moon-tasks/wxt-sign-firefox.ts
+++ b/etc/scripts/moon-tasks/wxt-sign-firefox.ts
@@ -19,7 +19,9 @@ const signArtifactTmpDir = path.resolve(
 const distDir = path.resolve(projectRoot, "target/extension/dist");
 
 // This extension ships on the beta channel only, so it is always signed as
-// unlisted regardless of the release tag. Unlisted submissions need no
+// unlisted. The release pipeline skips this task entirely on a prod tag (see
+// the isProdRelease guard in workflows/release-publish.ts), so there is no
+// release-tag branch to make here. Unlisted submissions need no
 // amo-metadata.json, but they do require an explicit gecko id (set in
 // wxt.config.ts).
 const channel = "unlisted";

--- a/etc/scripts/utils/release-tag.ts
+++ b/etc/scripts/utils/release-tag.ts
@@ -7,8 +7,13 @@ import { getReleaseTag } from "./get-envs";
 // Release tags use standard semver (e.g., v1.2.3).
 export const V0_TAG_PATTERN = /^v(0\.\d{5}\.\d{5})-(\d{2})$/;
 
+// A prod release is a real semver tag (v1.2.3 and up). v0 tags are the
+// beta/nightly channel.
+export const isProdRelease = (tag: string): boolean =>
+	!V0_TAG_PATTERN.test(tag);
+
 export const resolveFirefoxChannel = (tag: string): "listed" | "unlisted" =>
-	V0_TAG_PATTERN.test(tag) ? "unlisted" : "listed";
+	isProdRelease(tag) ? "listed" : "unlisted";
 
 export const resolveReleaseTag = async (): Promise<string> => {
 	const rawTag = getReleaseTag();

--- a/etc/scripts/workflows/release-publish.ts
+++ b/etc/scripts/workflows/release-publish.ts
@@ -1,7 +1,11 @@
 #!/usr/bin/env -S yarn dlx tsx
 import "zx/globals";
 import fse from "fs-extra";
-import { resolveFirefoxChannel, resolveReleaseTag } from "../utils/release-tag";
+import {
+	isProdRelease,
+	resolveFirefoxChannel,
+	resolveReleaseTag,
+} from "../utils/release-tag";
 import { workDirs } from "../utils/work-dirs";
 
 $.verbose = true;
@@ -15,6 +19,33 @@ const firefoxChannel = resolveFirefoxChannel(releaseTag);
 console.log(
 	`Resolved release tag "${releaseTag}" to Firefox channel "${firefoxChannel}"`,
 );
+
+// The ext-wxt "-next" artifacts (mcp-browser-kit-next-m2.xpi /
+// mcp-browser-kit-next-m3.zip) are a beta-channel preview of the next
+// extension. A prod release must not ship them, so both the collect and the
+// sign step are dropped from the pipeline on a non-v0 tag.
+const isProd = isProdRelease(releaseTag);
+console.log(
+	isProd
+		? `Prod release "${releaseTag}": skipping -next beta artifacts`
+		: `Beta release "${releaseTag}": building -next artifacts`,
+);
+
+const nextCollectArgs = isProd
+	? []
+	: [
+			"with-moon-task",
+			"--task",
+			"ext-wxt:wxt-collect-chrome",
+		];
+
+const nextSignArgs = isProd
+	? []
+	: [
+			"with-moon-task",
+			"--task",
+			"ext-wxt:wxt-sign-firefox",
+		];
 
 const hasNpmToken = Boolean(process.env.YARN_NPM_AUTH_TOKEN);
 
@@ -101,6 +132,7 @@ await $`${[
 	"with-moon-task",
 	"--task",
 	":build",
+	...nextCollectArgs,
 	"with-secret-variable",
 	"--name",
 	"FIREFOX_API_KEY",
@@ -114,9 +146,7 @@ await $`${[
 	"with-moon-task",
 	"--task",
 	"m2:extension-sign-firefox",
-	"with-moon-task",
-	"--task",
-	"ext-wxt:wxt-sign-firefox",
+	...nextSignArgs,
 	...npmAuthArgs,
 	"with-moon-task",
 	"--task",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1511,6 +1511,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@mcp-browser-kit/ext-wxt@workspace:apps/ext-wxt"
   dependencies:
+    "@playwright/test": "npm:^1.58.2"
     "@types/react": "npm:^19.2.14"
     "@types/react-dom": "npm:^19.2.3"
     "@wxt-dev/auto-icons": "npm:^1.1.1"


### PR DESCRIPTION
## Why

The `ext-wxt` `-next` artifacts (`mcp-browser-kit-next-m2.xpi` and `mcp-browser-kit-next-m3.zip`, added in #180) are a beta-channel preview of the next extension. A prod release — a real semver tag, `vX.Y.Z` with `X != 0` — must not ship them.

## What

### 1. Prod guard

`isProdRelease` is extracted from the existing v0-tag rule in `etc/scripts/utils/release-tag.ts`, and `resolveFirefoxChannel` is re-expressed in terms of it so the beta/prod definition is stated once. `release-publish.ts` uses it to drop both `ext-wxt:wxt-collect-chrome` and `ext-wxt:wxt-sign-firefox` from the Dagger chain on a prod tag.

`wxt-collect-chrome` rode on the generic `:build` task, which the release workflow can't conditionally omit, so `ext-wxt`'s `build` now stops at `wxt-zip` and collection is invoked explicitly from the workflow. This mirrors `apps/m2` and `apps/m3`, whose `build` stops at `extension-build` with signing driven from `release-publish.ts`.

### 2. Committed `webExt.binaries` instead of generated config

The `wxt-install-browser` task used `printf` to codegen `apps/ext-wxt/web-ext.config.ts` with absolute browser paths baked in. That made it unreviewable, forced a Biome exclusion, and made the moon cache hashes for `wxt-build`/`wxt-zip` machine-specific.

`wxt.config.ts` now resolves the Playwright-pinned binaries itself via `webExt.binaries`, filtering out anything not installed so web-ext falls back to its own discovery. The `wxt-dev` tasks depend on `scripts:browser-install` directly and set `PLAYWRIGHT_BROWSERS_PATH`.

### 3. `wxt-dev-firefox` Wayland crash

That task had never actually worked — it just had nothing depending on it. It failed after 31s with `connect ECONNREFUSED 127.0.0.1:<port>`.

A coredump showed Firefox aborting inside the Wayland client before it could bind the debugger port:

```
#1 raise
#6 libwayland-client.so.0
#7 wl_display_read_events
#8 libgdk-3.so.0
```

`si_code: SI_TKILL` with `raise` at frame #1 is a self-directed abort (`MOZ_CRASH`), not a memory fault. Playwright's Firefox build has no Wayland support. Setting `MOZ_ENABLE_WAYLAND=0` forces XWayland and fixes it; that alone is sufficient, `GDK_BACKEND=x11` isn't needed.

## Verification

- Stubbed `dagger` on `PATH` and ran the workflow under both tags: `v0.26032.00830-05` emits both ext-wxt tasks, `v1.2.3` emits neither, rest of the chain identical
- `moon run ext-wxt:wxt-dev` → `✔ Opened browser in 380 ms`
- `moon run ext-wxt:wxt-dev-firefox` → `✔ Opened browser in 1.409 s`
- `moon run ext-wxt:build` with `PLAYWRIGHT_BROWSERS_PATH` unset → binary fallback holds
- `yarn install` → `wxt prepare` postinstall clean with the static `@playwright/test` import
- `yarn compile` in `apps/ext-wxt` → typechecks under `strict`
- `moon check --all` → fails only on `ext-e2e:merge-reports`, pre-existing (needs CI shard blob reports)

## Note for reviewers

`web-ext.config.ts` is no longer gitignored or generated, but git won't delete an existing local copy — and it takes **precedence** over `wxt.config.ts`'s `webExt` (c12 treats those as `defaults`, the lowest tier). After pulling, run once:

```
rm -f apps/ext-wxt/web-ext.config.ts
```
