### PR TITLE
feat: publish m3 to the Chrome Web Store

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -38,6 +38,10 @@ jobs:
           RELEASE_TAG: ${{ github.ref_name }}
           FIREFOX_API_KEY: ${{ secrets.FIREFOX_API_KEY }}
           FIREFOX_API_SECRET: ${{ secrets.FIREFOX_API_SECRET }}
+          CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
+          CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
+          CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
+          CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
           # YARN_NPM_AUTH_TOKEN: ${{ secrets.YARN_NPM_AUTH_TOKEN }}
 
       - name: Upload target directory

--- a/.moon/tasks/tag-extension.yml
+++ b/.moon/tasks/tag-extension.yml
@@ -59,5 +59,15 @@ tasks:
     - '@group(extension-manifest)'
     - '@group(extension-vendors)'
     - '@group(amo-metadata)'
+  extension-publish-chrome:
+    toolchain: node
+    preset: utility
+    deps:
+    - extension-build
+    script: $workspaceRoot/etc/scripts/moon-tasks/extension-publish-chrome.ts
+    env:
+      PROJECT_ROOT: $projectRoot
+    inputs:
+    - '@group(extension-dist)'
 inheritedBy:
   tag: extension

--- a/apps/m3/src/manifest.json
+++ b/apps/m3/src/manifest.json
@@ -6,18 +6,11 @@
 	"description": "Allow MCP Browser Kit to interact with this browser.",
 	"permissions": [
 		"tabs",
-		"activeTab",
-		"tabCapture",
-		"scripting",
-		"alarms",
-		"storage",
 		"webNavigation"
 	],
 	"host_permissions": [
 		"http://*/*",
-		"https://*/*",
-		"*://localhost:*/*",
-		"*://127.0.0.1:*/*"
+		"https://*/*"
 	],
 	"content_security_policy": {},
 	"icons": {

--- a/docs/users/privacy.md
+++ b/docs/users/privacy.md
@@ -1,0 +1,99 @@
+# Privacy Policy — MCP Browser Kit
+
+Last updated: 2026-08-02
+
+MCP Browser Kit is an open-source project. This policy covers the browser
+extension ("the extension") and the MCP Browser Kit server ("the server") that
+you run on your own computer.
+
+The short version: **the extension sends nothing to the developer and nothing to
+the internet.** It talks only to software running on your own machine. What
+happens to that data afterwards is determined by the AI assistant you choose to
+connect, not by this extension.
+
+## What the extension accesses
+
+The extension is a remote control for your browser, driven by an AI assistant
+you connect yourself. To do that it accesses:
+
+- **Website content.** The HTML and visible text of a page, and the position and
+  labels of elements on it, so the assistant can read the page and click, type
+  or scroll on your behalf. This is read only when the assistant requests it, or
+  when a page you have open changes while the assistant is watching it.
+- **Web browsing activity.** The title, URL, window and active state of your open
+  tabs, so the assistant can tell your tabs apart and switch between them.
+
+The extension does **not** access or request your cookies, passwords, form
+autofill data, downloads, bookmarks, or browsing history beyond the tabs you
+currently have open. It takes no screenshots and records no audio or video.
+
+## Where that data goes
+
+The extension connects only to `localhost` — your own computer — on ports 2769
+to 2799. It scans that port range to find the MCP Browser Kit server, then
+maintains a WebSocket connection to it. Everything described above travels over
+that loopback connection and nowhere else.
+
+The extension makes no requests to the developer, to any analytics or crash
+reporting service, to any advertising network, or to any other remote server. It
+contains no tracking code. The developer of MCP Browser Kit never receives your
+data and has no ability to.
+
+## What happens after that
+
+The server passes the data to whichever MCP client and AI model **you** have
+configured. If that model runs on a third-party service, your page content and
+tab URLs are sent to that service by your own configuration, and that provider's
+privacy policy governs what they do with it. This is the point of the tool, but
+it is worth being explicit about: **if you point MCP Browser Kit at a hosted AI
+provider, the contents of the pages you expose to it leave your machine.**
+
+For this reason we recommend using a separate browser profile or a dedicated
+browser instance with MCP Browser Kit, so that sensitive pages are never in
+reach of the assistant. The server also has no authentication yet, so you should
+keep ports 21082 and 2769–2799 reachable only from your own device.
+
+## Storage and retention
+
+The extension stores no personal data. It keeps no logs, no history and no
+database, and writes nothing to `chrome.storage`. It holds no API keys or
+credentials of any kind. Data passes through the extension in memory and is not
+retained after it is handed to the local server.
+
+## Selling and sharing
+
+Your data is never sold. It is never transferred to third parties for any
+purpose unrelated to the extension's single purpose, never used to determine
+creditworthiness or for lending, and never used for advertising.
+
+## Remote code
+
+The extension executes no remote code. All of its code ships inside the
+published package and is reviewable in this repository. Messages received from
+the local server select from a fixed set of built-in operations; they cannot
+introduce new code into the extension or the page.
+
+## Permissions
+
+| Permission | Why it is needed |
+| --- | --- |
+| `tabs` | List your open tabs and their titles and URLs; open, switch to and close tabs at your request; deliver instructions to the right tab. |
+| `webNavigation` | Enumerate the frames of a page so content inside iframes can be read and interacted with. |
+| Access to all sites | The assistant must be able to act on whatever page you ask about, which can be on any site. Used to read page content and to identify tabs by URL. |
+
+## Source code
+
+MCP Browser Kit is MIT-licensed and developed in the open at
+<https://github.com/ndthanhdev/mcp-browser-kit>. Every claim in this policy can
+be checked against the source.
+
+## Changes
+
+Material changes to this policy will be published in this file, and its history
+is visible in the repository's commit log.
+
+## Contact
+
+Please open an issue at
+<https://github.com/ndthanhdev/mcp-browser-kit/issues> for any question about
+this policy.

--- a/etc/scripts/moon-tasks/extension-publish-chrome.ts
+++ b/etc/scripts/moon-tasks/extension-publish-chrome.ts
@@ -1,0 +1,181 @@
+#!/usr/bin/env -S yarn dlx tsx
+import "zx/globals";
+import { workDirs } from "@mcp-browser-kit/scripts/utils/work-dirs";
+import fse from "fs-extra";
+import {
+	getChromeClientId,
+	getChromeClientSecret,
+	getChromeExtensionId,
+	getChromeRefreshToken,
+	getProjectRoot,
+} from "../utils/get-envs";
+import { getExtensionName } from "../utils/get-extension-name";
+
+// zx wraps the global `fetch` with a verbose logger that dumps request bodies
+// and headers. Those carry the OAuth client secret, the refresh token and the
+// bearer access token, so verbose mode stays off here. This script runs no
+// shell commands, so nothing else depends on it.
+$.verbose = false;
+cd(workDirs.path);
+
+const projectRoot = getProjectRoot();
+const distDir = path.resolve(projectRoot, "target/extension/dist");
+const extensionId = getChromeExtensionId();
+
+const candidates = await glob(`${distDir}/*.zip`);
+
+if (candidates.length === 0) {
+	console.error(`No .zip file found in ${distDir}`);
+	process.exit(1);
+}
+
+// `dist` is not cleaned between builds locally, so pick the freshest zip.
+const withMtime = await Promise.all(
+	candidates.map(async (filePath) => ({
+		filePath,
+		mtimeMs: (await fse.stat(filePath)).mtimeMs,
+	})),
+);
+const zipPath = withMtime.sort((a, b) => b.mtimeMs - a.mtimeMs)[0].filePath;
+
+const extensionName = await getExtensionName(projectRoot);
+console.log(
+	`Publishing ${extensionName} (${zipPath}) to Chrome Web Store item ${extensionId}`,
+);
+
+// The Chrome Web Store API returns snake_case fields, which cannot be written as
+// literal property accesses without tripping the naming-convention lint.
+const readString = (
+	record: Record<string, unknown>,
+	key: string,
+): string | undefined => {
+	const value = record[key];
+	return typeof value === "string" ? value : undefined;
+};
+
+// The Chrome Web Store API only accepts short-lived access tokens, so the
+// long-lived refresh token is exchanged for one on every run.
+const tokenResponse = await fetch("https://oauth2.googleapis.com/token", {
+	method: "POST",
+	headers: {
+		"content-type": "application/x-www-form-urlencoded",
+	},
+	// Tuples rather than an object literal: the OAuth parameter names are
+	// snake_case and would violate the naming convention lint as object keys.
+	body: new URLSearchParams([
+		[
+			"client_id",
+			getChromeClientId(),
+		],
+		[
+			"client_secret",
+			getChromeClientSecret(),
+		],
+		[
+			"refresh_token",
+			getChromeRefreshToken(),
+		],
+		[
+			"grant_type",
+			"refresh_token",
+		],
+	]),
+});
+
+if (!tokenResponse.ok) {
+	console.error(
+		`Failed to refresh Chrome Web Store access token (${tokenResponse.status}): ${await tokenResponse.text()}`,
+	);
+	process.exit(1);
+}
+
+const tokenResult = (await tokenResponse.json()) as Record<string, unknown>;
+const accessToken = readString(tokenResult, "access_token");
+
+if (!accessToken) {
+	console.error("Chrome Web Store token response contained no access_token");
+	process.exit(1);
+}
+
+const authHeaders = {
+	authorization: `Bearer ${accessToken}`,
+	"x-goog-api-version": "2",
+};
+
+const uploadResponse = await fetch(
+	`https://www.googleapis.com/upload/chromewebstore/v1.1/items/${extensionId}?uploadType=media`,
+	{
+		method: "PUT",
+		headers: authHeaders,
+		body: await fse.readFile(zipPath),
+	},
+);
+
+const uploadBody = await uploadResponse.text();
+console.log(`Upload response (${uploadResponse.status}): ${uploadBody}`);
+
+if (!uploadResponse.ok) {
+	console.error("Chrome Web Store upload failed");
+	process.exit(1);
+}
+
+const uploadResult = JSON.parse(uploadBody) as {
+	uploadState?: string;
+	itemError?: Record<string, unknown>[];
+};
+
+if (uploadResult.uploadState === "FAILURE") {
+	for (const itemError of uploadResult.itemError ?? []) {
+		console.error(
+			readString(itemError, "error_detail") ?? JSON.stringify(itemError),
+		);
+	}
+	console.error("Chrome Web Store rejected the uploaded package");
+	process.exit(1);
+}
+
+const publishResponse = await fetch(
+	`https://www.googleapis.com/chromewebstore/v1.1/items/${extensionId}/publish?publishTarget=default`,
+	{
+		method: "POST",
+		headers: {
+			...authHeaders,
+			"content-length": "0",
+		},
+	},
+);
+
+const publishBody = await publishResponse.text();
+console.log(`Publish response (${publishResponse.status}): ${publishBody}`);
+
+if (!publishResponse.ok) {
+	console.error("Chrome Web Store publish failed");
+	process.exit(1);
+}
+
+const publishResult = JSON.parse(publishBody) as {
+	status?: string[];
+	statusDetail?: string[];
+};
+
+// `ITEM_PENDING_REVIEW` is the expected outcome for an extension that needs a
+// manual permissions review; it means the version was accepted.
+const acceptedStatuses = new Set([
+	"OK",
+	"ITEM_PENDING_REVIEW",
+]);
+const rejected = (publishResult.status ?? []).filter(
+	(status) => !acceptedStatuses.has(status),
+);
+
+if (rejected.length > 0) {
+	for (const detail of publishResult.statusDetail ?? []) {
+		console.error(detail);
+	}
+	console.error(
+		`Chrome Web Store publish returned unexpected status: ${rejected.join(", ")}`,
+	);
+	process.exit(1);
+}
+
+console.log(`Published ${extensionName} to the Chrome Web Store`);

--- a/etc/scripts/utils/get-envs.ts
+++ b/etc/scripts/utils/get-envs.ts
@@ -6,6 +6,10 @@ enum EnvVars {
 	FirefoxApiKey = "FIREFOX_API_KEY",
 	FirefoxApiSecret = "FIREFOX_API_SECRET",
 	FirefoxChannel = "FIREFOX_CHANNEL",
+	ChromeClientId = "CHROME_CLIENT_ID",
+	ChromeClientSecret = "CHROME_CLIENT_SECRET",
+	ChromeRefreshToken = "CHROME_REFRESH_TOKEN",
+	ChromeExtensionId = "CHROME_EXTENSION_ID",
 	YarnNpmAuthToken = "YARN_NPM_AUTH_TOKEN",
 	ReleaseTag = "RELEASE_TAG",
 }
@@ -36,6 +40,14 @@ export const getFirefoxChannel = (): "listed" | "unlisted" => {
 	});
 	return env[EnvVars.FirefoxChannel];
 };
+
+export const getChromeClientId = () => getEnv(EnvVars.ChromeClientId);
+
+export const getChromeClientSecret = () => getEnv(EnvVars.ChromeClientSecret);
+
+export const getChromeRefreshToken = () => getEnv(EnvVars.ChromeRefreshToken);
+
+export const getChromeExtensionId = () => getEnv(EnvVars.ChromeExtensionId);
 
 export const getYarnNpmAuthToken = () => getEnv(EnvVars.YarnNpmAuthToken);
 

--- a/etc/scripts/workflows/release-publish.ts
+++ b/etc/scripts/workflows/release-publish.ts
@@ -28,7 +28,7 @@ const isProd = isProdRelease(releaseTag);
 console.log(
 	isProd
 		? `Prod release "${releaseTag}": skipping -next beta artifacts`
-		: `Beta release "${releaseTag}": building -next artifacts`,
+		: `Beta release "${releaseTag}": building -next artifacts, skipping the Chrome Web Store publish`,
 );
 
 const nextCollectArgs = isProd
@@ -46,6 +46,29 @@ const nextSignArgs = isProd
 			"--task",
 			"ext-wxt:wxt-sign-firefox",
 		];
+
+// The Chrome Web Store has no equivalent of the Firefox `unlisted` channel, so
+// a v0 beta tag never reaches it; its m3 zip is only attached to the GitHub
+// Release. Prod tags upload the zip and publish it for review.
+const chromePublishArgs = isProd
+	? [
+			...[
+				"CHROME_CLIENT_ID",
+				"CHROME_CLIENT_SECRET",
+				"CHROME_REFRESH_TOKEN",
+				"CHROME_EXTENSION_ID",
+			].flatMap((name) => [
+				"with-secret-variable",
+				"--name",
+				name,
+				"--secret",
+				`env:${name}`,
+			]),
+			"with-moon-task",
+			"--task",
+			"m3:extension-publish-chrome",
+		]
+	: [];
 
 const hasNpmToken = Boolean(process.env.YARN_NPM_AUTH_TOKEN);
 
@@ -147,6 +170,7 @@ await $`${[
 	"--task",
 	"m2:extension-sign-firefox",
 	...nextSignArgs,
+	...chromePublishArgs,
 	...npmAuthArgs,
 	"with-moon-task",
 	"--task",


### PR DESCRIPTION
Adds Chrome Web Store publishing for `m3` and fixes the manifest problems the store surfaced on first upload.

## Publishing

`m3:extension-publish-chrome` uploads the zip produced by `m3:extension-build` and publishes it, using the Chrome Web Store API directly via `fetch` rather than adding a dependency, matching the hand-rolled style of `extension-sign-firefox`.

It runs only on prod tags, gated on the existing `isProd` flag. The store has no equivalent of Firefox's `unlisted` channel, and `scripts:versions-patch` produces 5-digit version segments for v0 tags that exceed the store's per-part limit of 65535, so beta tags keep attaching their zip to the GitHub Release only.

zx wraps the global `fetch` with a verbose logger that dumps request bodies and headers. That would have put the OAuth client secret, refresh token and bearer token into CI logs, so the task disables verbose mode.

Four new secrets are read by the release job: `CHROME_CLIENT_ID`, `CHROME_CLIENT_SECRET`, `CHROME_REFRESH_TOKEN`, `CHROME_EXTENSION_ID`.

## Manifest fixes

The store rejected the first upload with *"The manifest defines an invalid url"* for `*://localhost:*/*` and `*://127.0.0.1:*/*`. A match pattern's host may not carry a port. They were redundant anyway: Chrome ignores the port when matching, so `http://*/*` already covers the loopback ports the extension scans.

It then demanded a justification for nine permissions. Five have no call sites in the shipped MV3 bundle and were removed:

| Permission | Evidence |
| --- | --- |
| `activeTab` | No call site, and no `action` key that could ever trigger the grant |
| `tabCapture` | `captureTab` rejects in `driven-browser-driver-m3.ts:59-62`; the only screenshot path is MV2-only |
| `scripting` | `chrome.scripting` appears nowhere; `invokeJsFn` rejects in `driven-browser-driver-m3.ts:64-67` |
| `alarms` | Keep-alive uses `setInterval` (`keep-alive.ts:58`) |
| `storage` | Zero `storage.local` calls in the bundle; the only storage code is in a package m3 does not depend on |

`tabs` and `webNavigation` are kept and genuinely used. The only `executeScript` and `captureVisibleTab` strings in the bundle are the webextension-polyfill arity table at `bootstrap-extension.js:1459,1479`, not calls.

Dropping `scripting` and `tabCapture` also lets the listing answer the remote-code question with an unqualified no.

## Privacy policy

`docs/users/privacy.md`, required by the store for any extension handling user data. All egress is loopback-only, nothing reaches the developer, and page content reaches an AI provider only through the client the user configures.

## Verification

- `moon run scripts:check` passes
- `moon run m3:build` passes
- The publish script runs end to end to the expected 401 with dummy credentials, with no secrets in its output
- Built zip carries `permissions: ["tabs", "webNavigation"]` and `host_permissions: ["http://*/*", "https://*/*"]`

## Not yet verified

The trimmed permission set has **not** been exercised at runtime. `moon run ext-e2e:playwright-test -- --project=m3` should pass before this ships, since a wrongly removed permission fails at runtime rather than at build time.

The publish path itself cannot be tested until the store item exists: the first upload must be done manually to obtain `CHROME_EXTENSION_ID`, as the API cannot create an item with its listing metadata.